### PR TITLE
Avoid floor collision in the kitchen

### DIFF
--- a/room/kitchen_area.urdf.xml
+++ b/room/kitchen_area.urdf.xml
@@ -38,7 +38,7 @@
   />-->
 
   <!-- Finally, the 5 main blocks of the kitchen -->
-  <island_block block_pos="-2.1 -4.94 0.01" block_rpy="-0.01 0 3.141"/>
+  <island_block block_pos="-2.1 -4.94 0" block_rpy="0 0 3.141"/>
   
   <oven_block block_pos="-5.27 -6.85 0" block_rpy="0 0 0"/>
   


### PR DESCRIPTION
In the kitchen scene, the island block is colliding with the floor, causing dynamic simulation to propulse the kitchen in the air.
