### PR TITLE
The fridge has a closed-up collision model, this changes it to the visual

### DIFF
--- a/iai_kitchen/urdf/IAI_fridge_area.urdf.xacro
+++ b/iai_kitchen/urdf/IAI_fridge_area.urdf.xacro
@@ -23,7 +23,8 @@
     <collision>
         <origin xyz="0 0 0.01" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/collision/kitchen_fridge.stl"/>
+	    <mesh filename="package://iai_kitchen/meshes/racks/FridgeArea.dae"/>
+          <!--mesh filename="package://iai_kitchen/meshes/collision/kitchen_fridge.stl"/-->
         </geometry>
       </collision>
     </link>


### PR DESCRIPTION
This might not be the final solution, but it adds the essential opening in the front to the fridge.
The visual has an opening in the front, allowing manipulation. The collision model does not.

The fridge door is not accounted for at all now, though; it is part of the URDF model, featuring a joint and all, but the door doesn't collide with anything.

Also, see #38 for drawers not having collision objects; this is related, but this PR is independent from that problem.