### PR TITLE
replaced removed packages by new package

### DIFF
--- a/iai_maps/launch/json.launch
+++ b/iai_maps/launch/json.launch
@@ -1,5 +1,5 @@
 <launch>
-  <param name="initial_package" type="string" value="knowrob_map_data" />
+  <param name="initial_package" type="string" value="knowrob_maps" />
   <param name="initial_goal" type="string" value="owl_parse('package://iai_semantic_maps/owl/room.owl')" />
 
   <node name="json_prolog" pkg="json_prolog" type="json_prolog_node" cwd="node" output="screen" />

--- a/iai_semantic_maps/prolog/init.pl
+++ b/iai_semantic_maps/prolog/init.pl
@@ -14,8 +14,7 @@
 %% along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-:- register_ros_package(knowrob_map_tools).
-:- register_ros_package(knowrob_map_data).
+:- register_ros_package(knowrob_maps).
 :- register_ros_package(iai_maps).
 
 :- rdf_db:rdf_register_ns(iai_maps, 'http://knowrob.org/kb/room.owl#', [keep(true)]).


### PR DESCRIPTION
The packages knowrob_map_tools and knowrob_map_data don't exist anymore. Replaced their occurrences by the new package [knowrob_maps](https://github.com/knowrob/knowrob/tree/master/knowrob_maps).