### PR TITLE
FRONT_LINK -> MAIN

### DIFF
--- a/iai_kitchen/urdf_obj/IAI_drawers.urdf.xacro
+++ b/iai_kitchen/urdf_obj/IAI_drawers.urdf.xacro
@@ -75,7 +75,7 @@
     </link>
 
     <joint name="${parent}_${name}_joint" type="fixed">
-      <origin xyz="0 0 ${joint_origin_z}"/>
+      <origin xyz="-0.25 0 ${joint_origin_z}"/>
       <parent link="${parent}_main"/>
       <child link="${parent}_${name}_link"/>
     </joint>
@@ -97,7 +97,7 @@
     </link>
 
     <joint name="${parent}_${name}_barrier_right_joint" type="fixed">
-      <origin xyz="0 ${-board_y / 2 + board_z / 2} ${joint_origin_z + barrier_z/2 - board_z/2}"/>
+      <origin xyz="-0.25 ${-board_y / 2 + board_z / 2} ${joint_origin_z + barrier_z/2 - board_z/2}"/>
       <parent link="${parent}_main"/>
       <child link="${parent}_${name}_barrier_right_link"/>
     </joint>
@@ -119,7 +119,7 @@
     </link>
 
     <joint name="${parent}_${name}_barrier_left_joint" type="fixed">
-      <origin xyz="0 ${board_y / 2 - board_z / 2} ${joint_origin_z + barrier_z/2 - board_z/2}"/>
+      <origin xyz="-0.25 ${board_y / 2 - board_z / 2} ${joint_origin_z + barrier_z/2 - board_z/2}"/>
       <parent link="${parent}_main"/>
       <child link="${parent}_${name}_barrier_left_link"/>
     </joint>
@@ -141,7 +141,7 @@
     </link>
 
     <joint name="${parent}_${name}_barrier_back_joint" type="fixed">
-      <origin xyz="${-board_x / 2 + board_z / 2} 0 ${joint_origin_z + barrier_z/2 - board_z/2}"/>
+      <origin xyz="${-board_x / 2 + board_z / 2 - 0.25} 0 ${joint_origin_z + barrier_z/2 - board_z/2}"/>
       <parent link="${parent}_main"/>
       <child link="${parent}_${name}_barrier_back_link"/>
     </joint>
@@ -150,9 +150,35 @@
 
 
   <macro name="iai_vdrawer" params="name parent *origin">
+    <joint name="${name}_main_joint" type="prismatic">
+      <xacro:insert_block name="origin"/>
+      <parent link="${parent}"/>
+      <child link="${name}_main"/>
+      <axis xyz="1. 0. 0.0"/>
+      <limit effort="300" lower="0" upper="0.48" velocity="10"/>
+    </joint>
+
     <link name="${name}_main">
       <sphere_inertia radius="0" mass="0"/>
+      <visual>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <geometry>
+          <box size="0.025 0.295 1.325"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <geometry>
+          <box size="0.025 0.3 1.33"/>
+        </geometry>
+      </collision>
     </link>
+
+    <joint name="${name}_handle_joint" type="fixed">
+      <origin rpy="${-0.5*pi} 0 0" xyz="0.05 0.0 0.0"/>
+      <parent link="${name}_main" />
+      <child link="${name}_handle" />
+    </joint>
 
     <link name="${name}_handle">
       <sphere_inertia radius="0" mass="0"/>
@@ -166,43 +192,6 @@
         <origin xyz="0 0 0" rpy="${0.5*pi} 0 0" />
         <geometry>
           <mesh filename="package://iai_kitchen/meshes/handles/VHandle130.obj"/>
-        </geometry>
-      </collision>
-    </link>
-
-    <joint name="${name}_main_joint" type="prismatic">
-      <xacro:insert_block name="origin"/>
-      <parent link="${parent}"/>
-      <child link="${name}_main"/>
-      <axis xyz="1. 0. 0.0"/>
-      <limit effort="300" lower="0" upper="0.48" velocity="10"/>
-    </joint>
-
-
-    <joint name="${name}_handle_joint" type="fixed">
-      <origin rpy="${-0.5*pi} 0 0" xyz="0.05 0.0 0.0"/>
-      <parent link="${name}_front_link" />
-      <child link="${name}_handle" />
-    </joint>
-
-    <joint name="${name}_front_joint" type="fixed">
-      <origin rpy="0 0. 0" xyz="0.25 0 0"/>
-      <parent link="${name}_main"/>
-      <child link="${name}_front_link"/>
-    </joint>
-
-    <link name="${name}_front_link">
-      <sphere_inertia radius="0" mass="0"/>
-      <visual>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
-        <geometry>
-          <box size="0.025 0.295 1.325"/>
-        </geometry>
-      </visual>
-      <collision>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
-        <geometry>
-          <box size="0.025 0.3 1.33"/>
         </geometry>
       </collision>
     </link>

--- a/iai_kitchen/urdf_obj/IAI_oven_area.urdf.xacro
+++ b/iai_kitchen/urdf_obj/IAI_oven_area.urdf.xacro
@@ -56,11 +56,11 @@
   
   
   <iai_vdrawer name="${name}_area_left_drawer" parent="${name}_area">
-    <origin rpy="0 0 0" xyz="0.0 -0.45 0.06 "/>
+    <origin rpy="0 0 0" xyz="0.25 -0.45 0.06 "/>
   </iai_vdrawer>
   
   <iai_vdrawer name="${name}_area_right_drawer" parent="${name}_area">
-    <origin rpy="0 0 0" xyz="0.0 0.45 0.06 "/>
+    <origin rpy="0 0 0" xyz="0.25 0.45 0.06 "/>
   </iai_vdrawer>
   
   


### PR DESCRIPTION
Because it caused problems in the environment manipulation package of CRAM and was inconsistent with the other drawers, this PR changes the vdrawer macro so that the main link is not without a rigid-body.
The other drawers consist of a main link with the drawer as their mesh, a handle and a joint connecting them.
The vdrawer now too has a main link with a mesh (the front panel), some sub-parts (the boards and the handle) and joints connecting them with the main link.

This change was necessary from the CRAM perspective because the main link of a container is used to identify it. And also to get it's pose. Without a mesh the main link didn't have a pose.