### PR TITLE
Dm room gazebo and noetic

### DIFF
--- a/iai_refills_lab/urdf/dm_room.urdf.xacro
+++ b/iai_refills_lab/urdf/dm_room.urdf.xacro
@@ -4,117 +4,117 @@
   <xacro:include filename="$(find iai_refills_lab)/urdf/dm_shelf_macros.urdf.xacro"/>
   <xacro:include filename="$(find iai_refills_lab)/urdf/dm_shelves.urdf.xacro"/>
 
-  <!-- <link name="room_link"/> -->
+   <!-- <link name="room_link"/> -->
 
   <!-- Left side shelves -->
-  <!-- <shelf_1 parent="room_link" name="shelf_1"> -->
+  <!-- <xacro:shelf_1 parent="room_link" name="xacro:shelf_1"> -->
   <!--   <origin xyz="4.3223 -0.2415761 0.08515" rpy="0 0 -1.5756"/> -->
-  <!-- </shelf_1> -->
+  <!-- </xacro:shelf_1> -->
 
-  <shelf_1 parent="room_link" name="shelf_left_center_front">
+  <xacro:shelf_1 parent="room_link" name="shelf_left_center_front">
     <origin xyz="4.3223 -1.2415761 0.08515" rpy="0 0 -1.5756"/>
-  </shelf_1>
+  </xacro:shelf_1>
 
-  <shelf_1 parent="room_link" name="shelf_left_center_back">
+  <xacro:shelf_1 parent="room_link" name="shelf_left_center_back">
     <origin xyz="4.3223 -2.2415761 0.08515" rpy="0 0 -1.5756"/>
-  </shelf_1>
+  </xacro:shelf_1>
 
-  <shelf_1 parent="room_link" name="shelf_left_back">
+  <xacro:shelf_1 parent="room_link" name="shelf_left_back">
     <origin xyz="4.3223 -3.2415761 0.08515" rpy="0 0 -1.5756"/>
-  </shelf_1>
+  </xacro:shelf_1>
 
 
   <!-- Center shelves -->
-  <!-- <shelf_2 parent="room_link" name="shelf_2"> -->
+  <!-- <xacro:shelf_2 parent="room_link" name="xacro:shelf_2"> -->
   <!--   <origin xyz="1.75 -1.45 0.08515" rpy="0 0 3.09652"/> -->
-  <!-- </shelf_2> -->
+  <!-- </xacro:shelf_2> -->
 
-  <shelf_2 parent="room_link" name="shelf_center_front_middle">
+  <xacro:shelf_2 parent="room_link" name="shelf_center_front_middle">
     <origin xyz="0.75 -1.4 0.08515" rpy="0 0 3.09652"/>
-  </shelf_2>
+  </xacro:shelf_2>
 
-  <shelf_2 parent="room_link" name="shelf_center_front_right">
+  <xacro:shelf_2 parent="room_link" name="shelf_center_front_right">
     <origin xyz="-0.25 -1.35 0.08515" rpy="0 0 3.09652"/>
-  </shelf_2>
+  </xacro:shelf_2>
 
-  <shelf_2 parent="room_link" name="shelf_center_back_left">
+  <xacro:shelf_2 parent="room_link" name="shelf_center_back_left">
     <origin xyz="1.73 -2.0 0.08515" rpy="0 0 -3.18666530718"/>
-  </shelf_2>
+  </xacro:shelf_2>
 
-  <shelf_2 parent="room_link" name="shelf_center_back_middle">
+  <xacro:shelf_2 parent="room_link" name="shelf_center_back_middle">
     <origin xyz="0.73 -1.95 0.08515" rpy="0 0 -3.18666530718"/>
-  </shelf_2>
+  </xacro:shelf_2>
 
-  <shelf_2 parent="room_link" name="shelf_center_back_right">
+  <xacro:shelf_2 parent="room_link" name="shelf_center_back_right">
     <origin xyz="-0.27 -1.9 0.08515" rpy="0 0 -3.18666530718"/>
-  </shelf_2>
+  </xacro:shelf_2>
 
 
   <!-- Back shelves -->
-  <shelf_1 parent="room_link" name="shelf_back_1">
+  <xacro:shelf_1 parent="room_link" name="shelf_back_1">
     <origin xyz="3 -4.3 0.08515" rpy="0 0 ${pi}"/>
-  </shelf_1>
+  </xacro:shelf_1>
 
-  <shelf_1 parent="room_link" name="shelf_back_2">
+  <xacro:shelf_1 parent="room_link" name="shelf_back_2">
     <origin xyz="2 -4.3 0.08515" rpy="0 0 ${pi}"/>
-  </shelf_1>
+  </xacro:shelf_1>
 
-  <shelf_1 parent="room_link" name="shelf_back_3">
+  <xacro:shelf_1 parent="room_link" name="shelf_back_3">
     <origin xyz="1 -4.3 0.08515" rpy="0 0 ${pi}"/>
-  </shelf_1>
+  </xacro:shelf_1>
 
-  <shelf_1 parent="room_link" name="shelf_back_4">
+  <xacro:shelf_1 parent="room_link" name="shelf_back_4">
     <origin xyz="0 -4.3 0.08515" rpy="0 0 ${pi}"/>
-  </shelf_1>
+  </xacro:shelf_1>
 
-  <shelf_1 parent="room_link" name="shelf_back_5">
+  <xacro:shelf_1 parent="room_link" name="shelf_back_5">
     <origin xyz="-1 -4.3 0.08515" rpy="0 0 ${pi}"/>
-  </shelf_1>
+  </xacro:shelf_1>
 
-  <shelf_1 parent="room_link" name="shelf_back_6">
+  <xacro:shelf_1 parent="room_link" name="shelf_back_6">
     <origin xyz="-2 -4.3 0.08515" rpy="0 0 ${pi}"/>
-  </shelf_1>
+  </xacro:shelf_1>
 
 
   <!--Right side shelves -->
-  <shelf_1 parent="room_link" name="shelf_right_front">
+  <xacro:shelf_1 parent="room_link" name="shelf_right_front">
     <origin xyz="-2.6 -1.0 0.08515" rpy="0 0 1.5756"/>
-  </shelf_1>
+  </xacro:shelf_1>
 
-  <shelf_1 parent="room_link" name="shelf_right_center">
+  <xacro:shelf_1 parent="room_link" name="shelf_right_center">
     <origin xyz="-2.6 -2.0 0.08515" rpy="0 0 1.5756"/>
-  </shelf_1>
+  </xacro:shelf_1>
 
-  <shelf_1 parent="room_link" name="shelf_right_back">
+  <xacro:shelf_1 parent="room_link" name="shelf_right_back">
     <origin xyz="-2.6 -3.0 0.08515" rpy="0 0 1.5756"/>
-  </shelf_1>
+  </xacro:shelf_1>
 
 
-  <!-- Walls -->
+  <!-- xacro:walls -->
   <xacro:property name="wall_thickness" value="0.2" />
   <xacro:property name="wall_height" value="2.4" />
-  <wall parent="room_link" name="back_wall"
+  <xacro:wall parent="room_link" name="back_wall"
         size="8.0 ${wall_thickness} ${wall_height}">
     <origin xyz="1.0 -5.0 ${wall_height/2}" rpy="0 0 0"/>
-  </wall>
-  <wall parent="room_link" name="left_wall"
+  </xacro:wall>
+  <xacro:wall parent="room_link" name="left_wall"
         size="${wall_thickness} 9.6 ${wall_height}">
     <origin xyz="5.0 -0.3 ${wall_height/2}" rpy="0 0 0"/>
-  </wall>
-  <wall parent="room_link" name="front_wall"
+  </xacro:wall>
+  <xacro:wall parent="room_link" name="front_wall"
         size="5.0 ${wall_thickness} ${wall_height}">
     <origin xyz="2.5 4.6 ${wall_height/2}" rpy="0 0 0"/>
-  </wall>
-  <wall parent="room_link" name="right_wall"
+  </xacro:wall>
+  <xacro:wall parent="room_link" name="right_wall"
         size="${wall_thickness} 5.0 ${wall_height}">
     <origin xyz="-3.0 -2.5 ${wall_height/2}" rpy="0 0 0"/>
-  </wall>
-  <wall parent="room_link" name="back_corner_wall"
+  </xacro:wall>
+  <xacro:wall parent="room_link" name="back_corner_wall"
         size="3.0 ${wall_thickness} ${wall_height}">
     <origin xyz="-1.5 0.0 ${wall_height/2}" rpy="0 0 0"/>
-  </wall>
-  <wall parent="room_link" name="right_corner_wall"
+  </xacro:wall>
+  <xacro:wall parent="room_link" name="right_corner_wall"
         size="${wall_thickness} 4.6 ${wall_height}">
     <origin xyz="0 2.3 ${wall_height/2}" rpy="0 0 0"/>
-  </wall>
+  </xacro:wall>
 </robot>

--- a/iai_refills_lab/urdf/dm_shelf_macros.urdf.xacro
+++ b/iai_refills_lab/urdf/dm_shelf_macros.urdf.xacro
@@ -13,6 +13,11 @@
           <box size="0.004 0.65 0.05"/>
         </geometry>
       </collision>
+      <inertial>
+        <mass value="1."/>
+        <inertia ixx="0.1" ixy="0.1" ixz="0.1" iyy="0.1" iyz="0.1" izz="0.1"/>
+        <origin rpy="0 0 0" xyz="0.00312 0 0.11152"/>
+      </inertial>
     </link>
 
     <joint type="fixed" name="${name}_joint">
@@ -77,6 +82,11 @@
           <box size="0.988 0.65 0.043"/>
         </geometry>
       </collision>
+      <inertial>
+        <mass value="1."/>
+        <inertia ixx="0.1" ixy="0.1" ixz="0.1" iyy="0.1" iyz="0.1" izz="0.1"/>
+        <origin rpy="0 0 0" xyz="0.00312 0 0.11152"/>
+      </inertial>
     </link>
 
     <link name="${name}_left_support_link">
@@ -90,6 +100,11 @@
           <box size="0.004 0.65 0.12"/>
         </geometry>
       </collision>
+      <inertial>
+        <mass value="1."/>
+        <inertia ixx="0.1" ixy="0.1" ixz="0.1" iyy="0.1" iyz="0.1" izz="0.1"/>
+        <origin rpy="0 0 0" xyz="0.00312 0 0.11152"/>
+      </inertial>
     </link>
 
     <link name="${name}_right_support_link">
@@ -103,6 +118,11 @@
           <box size="0.004 0.65 0.12"/>
         </geometry>
       </collision>
+      <inertial>
+        <mass value="1."/>
+        <inertia ixx="0.1" ixy="0.1" ixz="0.1" iyy="0.1" iyz="0.1" izz="0.1"/>
+        <origin rpy="0 0 0" xyz="0.00312 0 0.11152"/>
+      </inertial>
     </link>
 
 
@@ -144,6 +164,11 @@
           <box size="1.1 1.05 0.173"/>
         </geometry>
       </collision>
+      <inertial>
+        <mass value="1."/>
+        <inertia ixx="0.1" ixy="0.1" ixz="0.1" iyy="0.1" iyz="0.1" izz="0.1"/>
+        <origin rpy="0 0 0" xyz="0.00312 0 0.11152"/>
+      </inertial>
     </link>
 
     <joint type="fixed" name="${name}_joint">
@@ -163,6 +188,11 @@
           <box size="1.04 0.12 2"/>
         </geometry>
       </collision>
+      <inertial>
+        <mass value="1."/>
+        <inertia ixx="0.1" ixy="0.1" ixz="0.1" iyy="0.1" iyz="0.1" izz="0.1"/>
+        <origin rpy="0 0 0" xyz="0.00312 0 0.11152"/>
+      </inertial>
     </link>
 
     <joint type="fixed" name="${name}_base_back_joint">
@@ -182,6 +212,11 @@
           <box size="1 0.78 0.043"/>
         </geometry>
       </collision>
+      <inertial>
+        <mass value="1."/>
+        <inertia ixx="0.1" ixy="0.1" ixz="0.1" iyy="0.1" iyz="0.1" izz="0.1"/>
+        <origin rpy="0 0 0" xyz="0.00312 0 0.11152"/>
+      </inertial>
     </link>
 
     <joint type="fixed" name="${name}_level_0_joint">
@@ -227,6 +262,11 @@
           <box size="0.992 0.435 0.043"/>
         </geometry>
       </collision>
+      <inertial>
+        <mass value="1."/>
+        <inertia ixx="0.1" ixy="0.1" ixz="0.1" iyy="0.1" iyz="0.1" izz="0.1"/>
+        <origin rpy="0 0 0" xyz="0.00312 0 0.11152"/>
+      </inertial>
     </link>
 
     <joint type="fixed" name="shelf_2_${name}_joint">
@@ -249,6 +289,11 @@
           <box size="1.1 0.8 0.145"/>
         </geometry>
       </collision>
+      <inertial>
+        <mass value="1."/>
+        <inertia ixx="0.1" ixy="0.1" ixz="0.1" iyy="0.1" iyz="0.1" izz="0.1"/>
+        <origin rpy="0 0 0" xyz="0.00312 0 0.11152"/>
+      </inertial>
     </link>
 
     <joint type="fixed" name="${name}_joint">
@@ -268,6 +313,11 @@
           <box size="0.05 0.54 1.6"/>
         </geometry>
       </collision>
+      <inertial>
+        <mass value="1."/>
+        <inertia ixx="0.1" ixy="0.1" ixz="0.1" iyy="0.1" iyz="0.1" izz="0.1"/>
+        <origin rpy="0 0 0" xyz="0.00312 0 0.11152"/>
+      </inertial>
     </link>
 
     <joint type="fixed" name="${name}_base_left_joint">
@@ -287,6 +337,11 @@
           <box size="0.05 0.54 1.6"/>
         </geometry>
       </collision>
+      <inertial>
+        <mass value="1."/>
+        <inertia ixx="0.1" ixy="0.1" ixz="0.1" iyy="0.1" iyz="0.1" izz="0.1"/>
+        <origin rpy="0 0 0" xyz="0.00312 0 0.11152"/>
+      </inertial>
     </link>
 
     <joint type="fixed" name="${name}_base_right_joint">
@@ -306,6 +361,11 @@
           <box size="1 0.05 1.45"/>
         </geometry>
       </collision>
+      <inertial>
+        <mass value="1."/>
+        <inertia ixx="0.1" ixy="0.1" ixz="0.1" iyy="0.1" iyz="0.1" izz="0.1"/>
+        <origin rpy="0 0 0" xyz="0.00312 0 0.11152"/>
+      </inertial>
     </link>
 
     <joint type="fixed" name="${name}_base_back_joint">
@@ -325,6 +385,11 @@
           <box size="0.992 0.54 0.043"/>
         </geometry>
       </collision>
+      <inertial>
+        <mass value="1."/>
+        <inertia ixx="0.1" ixy="0.1" ixz="0.1" iyy="0.1" iyz="0.1" izz="0.1"/>
+        <origin rpy="0 0 0" xyz="0.00312 0 0.11152"/>
+      </inertial>
     </link>
 
     <joint type="fixed" name="${name}_level_0_joint">
@@ -369,6 +434,11 @@
           <box size="${size}"/>
         </geometry>
       </collision>
+      <inertial>
+        <mass value="1."/>
+        <inertia ixx="0.1" ixy="0.1" ixz="0.1" iyy="0.1" iyz="0.1" izz="0.1"/>
+        <origin rpy="0 0 0" xyz="0.00312 0 0.11152"/>
+      </inertial>
     </link>
 
     <joint type="fixed" name="${name}_joint">

--- a/iai_refills_lab/urdf/dm_shelf_macros.urdf.xacro
+++ b/iai_refills_lab/urdf/dm_shelf_macros.urdf.xacro
@@ -23,45 +23,45 @@
   </xacro:macro>
 
   <xacro:macro name="shelf_divider" params="parent name dist1 dist2 dist3 dist4 dist5 dist6 dist7 dist8 dist9">
-    <divider_link parent="${parent}" name="${name}_divider_1">
+    <xacro:divider_link parent="${parent}" name="${name}_divider_1">
       <origin xyz="-0.495 0 0.024"/>
-    </divider_link>
+    </xacro:divider_link>
 
-    <divider_link parent="${parent}" name="${name}_divider_2">
+    <xacro:divider_link parent="${parent}" name="${name}_divider_2">
       <origin xyz="${-0.495 + dist1} 0 0.024"/>
-    </divider_link>
+    </xacro:divider_link>
 
-    <divider_link parent="${parent}" name="${name}_divider_3">
+    <xacro:divider_link parent="${parent}" name="${name}_divider_3">
       <origin xyz="${-0.495 + dist1 + dist2} 0 0.024"/>
-    </divider_link>
+    </xacro:divider_link>
 
-    <divider_link parent="${parent}" name="${name}_divider_4">
+    <xacro:divider_link parent="${parent}" name="${name}_divider_4">
       <origin xyz="${-0.495 + dist1 + dist2 + dist3} 0 0.024"/>
-    </divider_link>
+    </xacro:divider_link>
 
-    <divider_link parent="${parent}" name="${name}_divider_5">
+    <xacro:divider_link parent="${parent}" name="${name}_divider_5">
       <origin xyz="${-0.495 + dist1 + dist2 + dist3 + dist4} 0 0.024"/>
-    </divider_link>
+    </xacro:divider_link>
 
-    <divider_link parent="${parent}" name="${name}_divider_6">
+    <xacro:divider_link parent="${parent}" name="${name}_divider_6">
       <origin xyz="${-0.495 + dist1 + dist2 + dist3 + dist4 + dist5} 0 0.024"/>
-    </divider_link>
+    </xacro:divider_link>
 
-    <divider_link parent="${parent}" name="${name}_divider_7">
+    <xacro:divider_link parent="${parent}" name="${name}_divider_7">
       <origin xyz="${-0.495 + dist1 + dist2 + dist3 + dist4 + dist5 + dist6} 0 0.024"/>
-    </divider_link>
+    </xacro:divider_link>
 
-    <divider_link parent="${parent}" name="${name}_divider_8">
+    <xacro:divider_link parent="${parent}" name="${name}_divider_8">
       <origin xyz="${-0.495 + dist1 + dist2 + dist3 + dist4 + dist5 + dist6 + dist7} 0 0.024"/>
-    </divider_link>
+    </xacro:divider_link>
 
-    <divider_link parent="${parent}" name="${name}_divider_9">
+    <xacro:divider_link parent="${parent}" name="${name}_divider_9">
       <origin xyz="${-0.495 + dist1 + dist2 + dist3 + dist4 + dist5 + dist6 + dist7 + dist8} 0 0.024"/>
-    </divider_link>
+    </xacro:divider_link>
 
-    <divider_link parent="${parent}" name="${name}_divider_10">
+    <xacro:divider_link parent="${parent}" name="${name}_divider_10">
       <origin xyz="${-0.495 + dist1 + dist2 + dist3 + dist4 + dist5 + dist6 + dist7 + dist8 + dist9} 0 0.024"/>
-    </divider_link>
+    </xacro:divider_link>
   </xacro:macro>
 
 
@@ -125,7 +125,7 @@
     </joint>
 
 
-    <shelf_divider parent="${name}_link" name="${name}" dist1="${dist1}" dist2="${dist2}" dist3="${dist3}" dist4="${dist4}" dist5="${dist5}" dist6="${dist6}" dist7="${dist7}" dist8="${dist8}" dist9="${dist9}" />
+    <xacro:shelf_divider parent="${name}_link" name="${name}" dist1="${dist1}" dist2="${dist2}" dist3="${dist3}" dist4="${dist4}" dist5="${dist5}" dist6="${dist6}" dist7="${dist7}" dist8="${dist8}" dist9="${dist9}" />
   </xacro:macro>
 
 
@@ -192,25 +192,25 @@
 
 
 
-    <shelf_1_level name="${name}_level_1" parent="${name}_base" dist1="0.15" dist2="0.133" dist3="0.082" dist4="0.167" dist5="0.095" dist6="0.148" dist7="0.095" dist8="0.125" dist9="0" >
+    <xacro:shelf_1_level name="${name}_level_1" parent="${name}_base" dist1="0.15" dist2="0.133" dist3="0.082" dist4="0.167" dist5="0.095" dist6="0.148" dist7="0.095" dist8="0.125" dist9="0" >
       <origin xyz="0 0 0.50965" />
-    </shelf_1_level>
+    </xacro:shelf_1_level>
 
-    <shelf_1_level name="${name}_level_2" parent="${name}_base" dist1="0.177" dist2="0.208" dist3="0.147" dist4="0.20" dist5="0.124" dist6="0.14" dist7="0" dist8="0" dist9="0" >
+    <xacro:shelf_1_level name="${name}_level_2" parent="${name}_base" dist1="0.177" dist2="0.208" dist3="0.147" dist4="0.20" dist5="0.124" dist6="0.14" dist7="0" dist8="0" dist9="0" >
       <origin xyz="0 0 0.84465" />
-    </shelf_1_level>
+    </xacro:shelf_1_level>
 
-    <shelf_1_level name="${name}_level_3" parent="${name}_base" dist1="0" dist2="0" dist3="0" dist4="0" dist5="0" dist6="0" dist7="0" dist8="0" dist9="0" >
+    <xacro:shelf_1_level name="${name}_level_3" parent="${name}_base" dist1="0" dist2="0" dist3="0" dist4="0" dist5="0" dist6="0" dist7="0" dist8="0" dist9="0" >
       <origin xyz="0 0 1.22265" />
-    </shelf_1_level>
+    </xacro:shelf_1_level>
 
-    <shelf_1_level name="${name}_level_4" parent="${name}_base" dist1="0" dist2="0" dist3="0" dist4="0" dist5="0" dist6="0" dist7="0" dist8="0" dist9="0" >
+    <xacro:shelf_1_level name="${name}_level_4" parent="${name}_base" dist1="0" dist2="0" dist3="0" dist4="0" dist5="0" dist6="0" dist7="0" dist8="0" dist9="0" >
       <origin xyz="0 0 1.53565" />
-    </shelf_1_level>
+    </xacro:shelf_1_level>
 
-    <shelf_1_level name="${name}_level_5" parent="${name}_base" dist1="0" dist2="0" dist3="0" dist4="0" dist5="0" dist6="0" dist7="0" dist8="0" dist9="0" >
+    <xacro:shelf_1_level name="${name}_level_5" parent="${name}_base" dist1="0" dist2="0" dist3="0" dist4="0" dist5="0" dist6="0" dist7="0" dist8="0" dist9="0" >
       <origin xyz="0 0 1.86865" />
-    </shelf_1_level>
+    </xacro:shelf_1_level>
   </xacro:macro>
 
 
@@ -335,25 +335,25 @@
 
 
 
-    <shelf_2_level name="${name}_level_1" parent="${name}_base">
+    <xacro:shelf_2_level name="${name}_level_1" parent="${name}_base">
       <origin xyz="0 0.0 0.374"/>
-    </shelf_2_level>
+    </xacro:shelf_2_level>
 
-    <shelf_2_level name="${name}_level_2" parent="${name}_base">
+    <xacro:shelf_2_level name="${name}_level_2" parent="${name}_base">
       <origin xyz="0 0.0 0.624"/>
-    </shelf_2_level>
+    </xacro:shelf_2_level>
 
-    <shelf_2_level name="${name}_level_3" parent="${name}_base">
+    <xacro:shelf_2_level name="${name}_level_3" parent="${name}_base">
       <origin xyz="0 0.0 0.864"/>
-    </shelf_2_level>
+    </xacro:shelf_2_level>
 
-    <shelf_2_level name="${name}_level_4" parent="${name}_base">
+    <xacro:shelf_2_level name="${name}_level_4" parent="${name}_base">
       <origin xyz="0 0.0 1.17"/>
-    </shelf_2_level>
+    </xacro:shelf_2_level>
 
-    <shelf_2_level name="${name}_level_5" parent="${name}_base">
+    <xacro:shelf_2_level name="${name}_level_5" parent="${name}_base">
       <origin xyz="0 0.0 1.42"/>
-    </shelf_2_level>
+    </xacro:shelf_2_level>
   </xacro:macro>
 
 

--- a/iai_refills_lab/urdf/dm_shelves.urdf.xacro
+++ b/iai_refills_lab/urdf/dm_shelves.urdf.xacro
@@ -5,11 +5,11 @@
 
   <link name="room_link"/>
 
-  <shelf_1 parent="room_link" name="shelf_1">
+  <xacro:shelf_1 parent="room_link" name="shelf_1">
     <origin xyz="4.3223 -0.2415761 0.08515" rpy="0 0 -1.5756"/>
-  </shelf_1>
+  </xacro:shelf_1>
 
-  <shelf_2 parent="room_link" name="shelf_2">
+  <xacro:shelf_2 parent="room_link" name="shelf_2">
     <origin xyz="1.75 -1.45 0.08515" rpy="0 0 3.09652"/>
-  </shelf_2>
+  </xacro:shelf_2>
 </robot>


### PR DESCRIPTION
# Description
This PR adds inertial tags to all links in the dm_room urdf macro. This allows the spawning of the urdf in gazebo.
Furthermore, the xacro namespace is added to all macro tags because it is required by the ROS noetic version of xacro. 

All added inertial tags are all the same and are displayed below
~~~
<inertial>
    <mass value="1."/>
    <inertia ixx="0.1" ixy="0.1" ixz="0.1" iyy="0.1" iyz="0.1" izz="0.1"/>
    <origin rpy="0 0 0" xyz="0.00312 0 0.11152"/>
</inertial>
~~~
This shouldn't be a problem because all links are connected via fixed joints and aren't supposed to move.