### PR TITLE
Update room.urdf.xacro for noetic

### DIFF
--- a/iai_kitchen/launch/gazebo_spawn_kitchen.launch
+++ b/iai_kitchen/launch/gazebo_spawn_kitchen.launch
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
 <launch>
-  <arg name="model" default="$(find iai_kitchen)/urdf/IAI_kitchen.urdf.xacro"/>
-  <param name="kitchen_description" command="$(find xacro)/xacro.py '$(arg model)'" />
+  <arg name="model" default="$(find iai_kitchen)/urdf_obj/iai_kitchen_python.urdf.xacro"/>
+  <param name="kitchen_description" command="$(find xacro)/xacro '$(arg model)'" />
                             
 
   <arg
@@ -32,7 +32,7 @@
   <node
     name="kitchen_state_publisher_gazebo"
     pkg="robot_state_publisher"
-    type="state_publisher" >
+    type="robot_state_publisher" >
     <param name="tf_prefix" value="iai_kitchen"/>
     <remap from="robot_description" to="kitchen_description"/>
     <remap from="joint_states" to="kitchen_joint_states"/>

--- a/iai_kitchen/launch/publish_iai_kitchen_on_tf.launch
+++ b/iai_kitchen/launch/publish_iai_kitchen_on_tf.launch
@@ -6,8 +6,8 @@
   <!-- todo(lisca): insert the tf_prefix "iai_kitchen" in
                     the right way and the right place -->
 
-  <arg name="model" default="$(find iai_kitchen)/urdf/IAI_kitchen.urdf.xacro"/>
-  <param name="kitchen_description" command="$(find xacro)/xacro.py '$(arg model)'" />
+  <arg name="model" default="$(find iai_kitchen)/urdf_obj/iai_kitchen_python.urdf.xacro"/>
+  <param name="kitchen_description" command="$(find xacro)/xacro '$(arg model)'" />
 
   <node pkg="tf"
         type="static_transform_publisher"
@@ -24,7 +24,7 @@
   
   <node name="kitchen_state_publisher"
         pkg="robot_state_publisher"
-        type="state_publisher" >
+        type="robot_state_publisher" >
     <remap from="robot_description" to="kitchen_description"/>
     <remap from="joint_states" to="kitchen_joint_states"/>
     <!-- param name="tf_prefix" value="iai_kitchen"/-->

--- a/iai_kitchen/urdf_obj/IAI_dish_washer.urdf.xacro
+++ b/iai_kitchen/urdf_obj/IAI_dish_washer.urdf.xacro
@@ -7,11 +7,11 @@
   <xacro:macro name="iai_dish_washer" params="name parent *origin">
      <link name="${name}_main">
 
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/misc/DishWasher.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/misc/DishWasher.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -24,11 +24,11 @@
 
     <link name="${name}_door">
 
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0.055 0" rpy="${0.5*pi} 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/misc/DishWasherDoor.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/misc/DishWasherDoor.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -40,11 +40,11 @@
     </link>
 
     <link name="${name}_door_handle">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
         </geometry>
       </visual>
       <collision>

--- a/iai_kitchen/urdf_obj/IAI_drawers.urdf.xacro
+++ b/iai_kitchen/urdf_obj/IAI_drawers.urdf.xacro
@@ -59,7 +59,7 @@
   <xacro:property name="barrier_z" value="0.1"/>
   <xacro:macro name="iai_vdrawer_board" params="name parent joint_origin_z">
     <link name="${parent}_board_${name}_link">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin rpy="0 0 0" xyz="0 0 0"/>
         <geometry>
@@ -81,7 +81,7 @@
     </joint>
 
     <link name="${parent}_barrier_${name}_right_link">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin rpy="0 0 0" xyz="0 0 0"/>
         <geometry>
@@ -103,7 +103,7 @@
     </joint>
 
     <link name="${parent}_barrier_${name}_left_link">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin rpy="0 0 0" xyz="0 0 0"/>
         <geometry>
@@ -125,7 +125,7 @@
     </joint>
 
     <link name="${parent}_barrier_${name}_back_link">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin rpy="0 0 0" xyz="0 0 0"/>
         <geometry>
@@ -159,12 +159,15 @@
     </joint>
 
     <link name="${name}_main">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin rpy="0 0 0" xyz="0 0 0"/>
         <geometry>
           <box size="0.025 0.3 1.33"/>
         </geometry>
+        <material name="KitchenLightGray">
+          <color rgba="0.7 0.7 0.7 1.0"/>
+        </material>
       </visual>
       <collision>
         <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -180,7 +183,7 @@
       <origin rpy="0 0 0" xyz="-0.03 0.0 0.0"/>
     </joint>
     <link name="${name}_main_padding">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin rpy="0 0 0" xyz="0 0 0"/>
         <geometry>
@@ -203,11 +206,11 @@
     </joint>
 
     <link name="${name}_handle">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="${0.5*pi} 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/handles/VHandle130.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/handles/VHandle130.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -245,11 +248,11 @@
   
   <xacro:macro name="iai_generic_drawer" params="name parent width height *origin *handle_origin">
     <link name="${name}_main">      
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_${width}_${height}.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_${width}_${height}.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -261,11 +264,11 @@
     </link>
 
     <link name="${name}_handle">      
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/handles/Handle${width}.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/handles/Handle${width}.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -300,11 +303,11 @@
   
   <xacro:macro name="iai_generic_panel" params="name parent width *origin">
     <link name="${name}">      
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/drawers/Panel_${width}.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/drawers/Panel_${width}.dae"/>
         </geometry>
       </visual>
       <collision>

--- a/iai_kitchen/urdf_obj/IAI_fridge.urdf.xacro
+++ b/iai_kitchen/urdf_obj/IAI_fridge.urdf.xacro
@@ -8,11 +8,11 @@
 
      <link name="${name}_main">
 
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/misc/Fridge.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/misc/Fridge.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -41,11 +41,11 @@
 
     <link name="${name}_door">
 
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/misc/FridgeDoor.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/misc/FridgeDoor.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -71,11 +71,11 @@
 
     <link name="${name}_door_handle">
 
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/handles/VHandle90.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/handles/VHandle90.dae"/>
         </geometry>
       </visual>
       <collision>

--- a/iai_kitchen/urdf_obj/IAI_fridge_area.urdf.xacro
+++ b/iai_kitchen/urdf_obj/IAI_fridge_area.urdf.xacro
@@ -9,15 +9,15 @@
 
   <xacro:macro name="iai_fridge_area" params="parent name *origin">
     <link name="${name}_footprint">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
     </link>
 
     <link name="${name}">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
     	  <origin xyz="0 0 0.01" rpy="0 0 0" />
     	  <geometry>
-    	    <mesh filename="package://iai_kitchen/meshes/racks/FridgeArea.obj"/>
+    	    <mesh filename="package://iai_kitchen/meshes/racks/FridgeArea.dae"/>
     	  </geometry>
     	</visual>
       <collision>

--- a/iai_kitchen/urdf_obj/IAI_kitchen_island.urdf.xacro
+++ b/iai_kitchen/urdf_obj/IAI_kitchen_island.urdf.xacro
@@ -11,14 +11,14 @@
   <xacro:macro name="iai_kitchen_island" params="parent name *origin">
      
     <link name="${name}_footprint">    
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
     </link>
     <link name="${name}">    
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/racks/IslandArea.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/racks/IslandArea.dae"/>
         </geometry>
       </visual>  
       <collision>
@@ -42,7 +42,7 @@
     </joint>
     
     <link name="${name}_surface">    
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <collision>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry>
@@ -59,11 +59,11 @@
     
     
     <link name="${name}_stove">    
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
           <origin xyz="0 0 0" rpy="0 0 0" />
           <geometry>
-            <mesh filename="package://iai_kitchen/meshes/misc/Stove.obj"/>
+            <mesh filename="package://iai_kitchen/meshes/misc/Stove.dae"/>
           </geometry>
         </visual>
         <collision>

--- a/iai_kitchen/urdf_obj/IAI_kitchen_walls.urdf.xacro
+++ b/iai_kitchen/urdf_obj/IAI_kitchen_walls.urdf.xacro
@@ -6,7 +6,7 @@
     <!-- LINKS -->
     
     <link name="kitchen_wall_1">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 1.25" rpy="0 0 0" />
         <geometry>
@@ -22,7 +22,7 @@
     </link>
       
     <link name="kitchen_wall_2">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 1.25" rpy="0 0 0" />
         <geometry>
@@ -38,7 +38,7 @@
     </link>
       
     <link name="kitchen_wall_3">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 1.25" rpy="0 0 0" />
         <geometry>
@@ -54,7 +54,7 @@
     </link>
       
     <link name="kitchen_wall_4">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0.35" rpy="0 0 0" />
         <geometry>
@@ -70,7 +70,7 @@
     </link>
       
     <link name="kitchen_wall_5">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0.35" rpy="0 0 0" />
         <geometry>
@@ -88,7 +88,7 @@
     
     
     <link name="kitchen_wall_6">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0.35" rpy="0 0 0" />
         <geometry>
@@ -104,7 +104,7 @@
     </link>   
 
     <link name="kitchen_wall_7">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0.375" rpy="0 0 0" />
         <geometry>

--- a/iai_kitchen/urdf_obj/IAI_oven.urdf.xacro
+++ b/iai_kitchen/urdf_obj/IAI_oven.urdf.xacro
@@ -9,11 +9,11 @@
     
     <link name="${name}_main">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/oven/OvenMain.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/oven/OvenMain.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -26,11 +26,11 @@
     
     <link name="${name}_door">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="${0.5*pi} 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/oven/OvenDoor.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/oven/OvenDoor.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -43,11 +43,11 @@
     
     <link name="${name}_door_handle">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -61,11 +61,11 @@
     
     <link name="${name}_panel">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/oven/OvenPanel.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/oven/OvenPanel.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -148,7 +148,7 @@
   <xacro:macro name="iai_oven_knob" params="name parent xyz">
     <link name="${name}">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 ${0.5 * pi} 0" />
         <geometry>
@@ -178,7 +178,7 @@
 <!--
   <link name="oven_footprint">
     
-    <sphere_inertia radius="0" mass="0"/>
+    <xacro:sphere_inertia radius="0" mass="0"/>
   </link>
   <iai_oven name="iai_oven" parent="oven_footprint"/>
   -->

--- a/iai_kitchen/urdf_obj/IAI_oven_area.urdf.xacro
+++ b/iai_kitchen/urdf_obj/IAI_oven_area.urdf.xacro
@@ -10,15 +10,15 @@
   
   <xacro:macro name="iai_oven_area" params="parent name *origin">
   <link name="${name}_area_footprint">    
-    <sphere_inertia radius="0" mass="0"/>
+    <xacro:sphere_inertia radius="0" mass="0"/>
   </link>
   
   <link name="${name}_area">    
-    <sphere_inertia radius="0" mass="0"/>
+    <xacro:sphere_inertia radius="0" mass="0"/>
     <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/racks/OvenArea.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/racks/OvenArea.dae"/>
         </geometry>
       </visual>
     <collision>

--- a/iai_kitchen/urdf_obj/IAI_sink_area.urdf.xacro
+++ b/iai_kitchen/urdf_obj/IAI_sink_area.urdf.xacro
@@ -10,15 +10,15 @@
   
   <xacro:macro name="iai_sink_area" params="parent name *origin">
   <link name="${name}_footprint">    
-    <sphere_inertia radius="0" mass="0"/>
+    <xacro:sphere_inertia radius="0" mass="0"/>
   </link>
   
   <link name="${name}">    
-    <sphere_inertia radius="0" mass="0"/>
+    <xacro:sphere_inertia radius="0" mass="0"/>
     <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/racks/SinkArea.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/racks/SinkArea.dae"/>
         </geometry>
       </visual>
     <collision>
@@ -43,7 +43,7 @@
   
   
   <link name="${name}_surface">
-    <sphere_inertia radius="0" mass="0"/>
+    <xacro:sphere_inertia radius="0" mass="0"/>
     <collision>
       <origin xyz="0 -0.225 0" rpy="0 0 0" />
       <geometry>
@@ -62,11 +62,11 @@
   
   
   <link name="${name}_sink">    
-    <sphere_inertia radius="0" mass="0"/>
+    <xacro:sphere_inertia radius="0" mass="0"/>
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/misc/Sink.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/misc/Sink.dae"/>
       </geometry>
     </visual>
     <collision>

--- a/iai_kitchen/urdf_obj/IAI_tables.urdf.xacro
+++ b/iai_kitchen/urdf_obj/IAI_tables.urdf.xacro
@@ -3,11 +3,11 @@
 <robot name="iai_table" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="iai_table_1" params="name parent *origin">
     <link name="${name}_main">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0.3619" rpy="0 0 0"/>
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/misc/big_table_1.stl"/>
+          <mesh filename="package://iai_kitchen/meshes/misc/big_table_1.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -26,7 +26,7 @@
 
   <xacro:macro name="jokkmokk_table" params="name parent *origin">
     <link name="${name}_main">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
         <geometry>
@@ -50,7 +50,7 @@
 
   <xacro:macro name="jokkmokk_chair" params="name parent *origin">
     <link name="${name}_main">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
         <geometry>
@@ -73,7 +73,7 @@
 
   <xacro:macro name="iai_dining_area" params="parent name *origin">
     <link name="${name}_footprint">
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
     </link>
     <joint name="${name}_footprint_joint" type="fixed">
       <xacro:insert_block name="origin" />

--- a/iai_kitchen/urdf_obj/iai_kitchen_python.urdf.xacro
+++ b/iai_kitchen/urdf_obj/iai_kitchen_python.urdf.xacro
@@ -24,7 +24,7 @@
   </xacro:macro>
 
   <link name="room_link">
-    <sphere_inertia radius="0" mass="0"/>
+    <xacro:sphere_inertia radius="0" mass="0"/>
   </link>
   <xacro:if value="${simulated}">
     <link name="world"/>

--- a/iai_kitchen/urdf_obj/sink_area.urdf.xacro
+++ b/iai_kitchen/urdf_obj/sink_area.urdf.xacro
@@ -1,17 +1,12 @@
 <?xml version="1.0"?>
 
 <robot name="iai_kitchen_sink_area" xmlns:xacro="http://ros.org/wiki/xacro">
-<!--
-  <xacro:include filename="$(find iai_kitchen)/urdf/drawers.xacro" />
--->
 
   <xacro:property name="pi" value="3.1415926535897931" />
 
-
-
     <link name="sink_area_footprint">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <!-- ???vizualize footprint??? -->
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -23,12 +18,12 @@
     
     <link name="sink_area_main">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <!-- ???vizualize footprint??? -->
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/SinkArea.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/SinkArea.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -52,12 +47,12 @@
     <!-- LEFT BLOCK -->
     <link name="sink_area_drawer_left_bottom">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <!-- ???vizualize footprint??? -->
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/SinkAreaMedDrawer.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/SinkAreaMedDrawer.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -80,12 +75,12 @@
     
     <link name="sink_area_drawer_left_bottom_handle">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <!-- ???vizualize footprint??? -->
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/SinkAreaBigHandle.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/SinkAreaBigHandle.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -108,12 +103,12 @@
     
     <link name="sink_area_drawer_left_center">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <!-- ???vizualize footprint??? -->
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/SinkAreaMedDrawer.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/SinkAreaMedDrawer.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -136,11 +131,11 @@
     
     <link name="sink_area_drawer_left_center_handle">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/SinkAreaBigHandle.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/SinkAreaBigHandle.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -161,12 +156,12 @@
     
     <link name="sink_area_drawer_left_top">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <!-- ???vizualize footprint??? -->
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/SinkAreaSmallDrawer.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/SinkAreaSmallDrawer.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -188,11 +183,11 @@
     
     <link name="sink_area_drawer_left_top_handle">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/SinkAreaBigHandle.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/SinkAreaBigHandle.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -217,11 +212,11 @@
     
     <link name="sink_area_inner_dishwasher">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/SinkAreaInnerDishWasher.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/SinkAreaInnerDishWasher.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -240,11 +235,11 @@
     
     <link name="sink_area_dishwasher_door">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/SinkAreaDishWasherDoor.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/SinkAreaDishWasherDoor.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -265,11 +260,11 @@
     
     <link name="sink_area_dishwasher_handle">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/SinkAreaSmallHandle.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/SinkAreaSmallHandle.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -293,11 +288,11 @@
     
     <link name="sink_area_panel">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/SinkAreaPanel.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/SinkAreaPanel.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -317,11 +312,11 @@
     
     <link name="sink_area_trash">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/SinkAreaTrash.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/SinkAreaTrash.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -342,11 +337,11 @@
     
     
     <link name="sink_area_trash_handle">      
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/SinkAreaSmallHandle.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/SinkAreaSmallHandle.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -365,11 +360,11 @@
     
     
     <link name="sink_area_sink">      
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://iai_kitchen/meshes/SinkAreaSink.obj"/>
+          <mesh filename="package://iai_kitchen/meshes/SinkAreaSink.dae"/>
         </geometry>
       </visual>
       <collision>

--- a/iai_kitchen_defs/Media/models/cash_register.urdf.xml
+++ b/iai_kitchen_defs/Media/models/cash_register.urdf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<robot name="cash_register">
+<robot name="cash_register" xmlns:xacro="http://www.ros.org/wiki/xacro">
   
-  <macro name="cash_register" params="name parent xyz rpy">
+  <xacro:macro name="cash_register" params="name parent xyz rpy">
     
     <link name="${parent}_${name}_register_link">    
       <visual>
@@ -30,6 +30,6 @@
       <child link="${parent}_${name}_register_link"/>
     </joint>
     
-  </macro>
+  </xacro:macro>
   
 </robot>

--- a/iai_kitchen_defs/Media/models/chair.urdf.xml
+++ b/iai_kitchen_defs/Media/models/chair.urdf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<robot name="chair">
+<robot name="chair" xmlns:xacro="http://www.ros.org/wiki/xacro">
   
-  <macro name="chair" params="name parent xyz rpy">
+  <xacro:macro name="chair" params="name parent xyz rpy">
     
     <link name="${parent}_${name}_chair_link">    
       <visual>
@@ -30,6 +30,6 @@
       <child link="${parent}_${name}_chair_link"/>
     </joint>
     
-  </macro>
+  </xacro:macro>
   
 </robot>

--- a/iai_kitchen_defs/Media/models/cnc.urdf.xml
+++ b/iai_kitchen_defs/Media/models/cnc.urdf.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
-<robot name="cnc">
+<robot name="cnc" xmlns:xacro="http://www.ros.org/wiki/xacro">
   
   <include filename="$(find iai_maps)/defs/util_defs.xml"/>  
   
-  <macro name="cnc" params="name parent xyz rpy">
+  <xacro:macro name="cnc" params="name parent xyz rpy">
     
     <link name="${parent}_${name}_cnc_link">    
       <visual>
@@ -20,7 +20,7 @@
         <origin rpy="0 0 0" xyz="0 0 0" />
       </collision>
       
-      <sphere_inertia radius="2" mass="1000"/>
+      <xacro:sphere_inertia radius="2" mass="1000"/>
 
     </link>
     
@@ -30,6 +30,6 @@
       <child link="${parent}_${name}_cnc_link"/>
     </joint>
     
-  </macro>
+  </xacro:macro>
   
 </robot>

--- a/iai_kitchen_defs/Media/models/glasses.urdf.xml
+++ b/iai_kitchen_defs/Media/models/glasses.urdf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<robot name="glasses">
+<robot name="glasses" xmlns:xacro="http://www.ros.org/wiki/xacro">
   
-  <macro name="glasses" params="name parent xyz rpy">
+  <xacro:macro name="glasses" params="name parent xyz rpy">
     
     <link name="${parent}_${name}_glasses_link">    
       <visual>
@@ -30,6 +30,6 @@
       <child link="${parent}_${name}_glasses_link"/>
     </joint>
     
-  </macro>
+  </xacro:macro>
   
 </robot>

--- a/iai_kitchen_defs/Media/models/test_glasses.urdf.xml
+++ b/iai_kitchen_defs/Media/models/test_glasses.urdf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<robot name="test_glasses">
+<robot name="test_glasses" xmlns:xacro="http://www.ros.org/wiki/xacro">
   
-  <macro name="test_glasses" params="name parent xyz rpy">
+  <xacro:macro name="test_glasses" params="name parent xyz rpy">
     
     <link name="${parent}_${name}_test_glasses_link">    
       <visual>
@@ -30,6 +30,6 @@
       <child link="${parent}_${name}_test_glasses_link"/>
     </joint>
     
-  </macro>
+  </xacro:macro>
   
 </robot>

--- a/iai_kitchen_defs/Media/models/wine_cooler.urdf.xml
+++ b/iai_kitchen_defs/Media/models/wine_cooler.urdf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<robot name="wine_cooler">
+<robot name="wine_cooler" xmlns:xacro="http://www.ros.org/wiki/xacro">
   
-  <macro name="wine_cooler" params="name parent xyz rpy">
+  <xacro:macro name="wine_cooler" params="name parent xyz rpy">
     
     <link name="${parent}_${name}_wine_cooler_link">    
       <visual>
@@ -31,6 +31,6 @@
       <child link="${parent}_${name}_wine_cooler_link"/>
     </joint>
     
-  </macro>
+  </xacro:macro>
   
 </robot>

--- a/iai_kitchen_defs/defs/ias_kitchen/cuboid.xml
+++ b/iai_kitchen_defs/defs/ias_kitchen/cuboid.xml
@@ -8,9 +8,9 @@
   <!-- Cuboid -->
   <!--        -->
 
-  <macro name="cuboid" params="block_pos block_rpy">
+  <xacro:macro name="cuboid" params="block_pos block_rpy">
 
-    <counter parent="cuboid"
+    <xacro:counter parent="cuboid"
       name="cuboid_top"
       pos_x="0" pos_y="0" pos_z="0"
       roll="0" pitch="0" yaw="0"
@@ -27,7 +27,7 @@
 
     <link name="cuboid_link">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -37,6 +37,6 @@
       </visual>
     </link>
 
-  </macro>
+  </xacro:macro>
 
 </robot>

--- a/iai_kitchen_defs/defs/ias_kitchen/fridge_block.xml
+++ b/iai_kitchen_defs/defs/ias_kitchen/fridge_block.xml
@@ -8,28 +8,28 @@
   <!-- Fridge Area -->
   <!--             -->
 
-  <macro name="fridge_block" params="block_pos block_rpy">
+  <xacro:macro name="fridge_block" params="block_pos block_rpy">
 
-    <counter parent="fridge_block"
+    <xacro:counter parent="fridge_block"
       name="counter_top_fridge"
       pos_x="0" pos_y="0" pos_z="1.48"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.6" size_z="0.03"
     />
-    <counter_side parent="fridge_block"
+    <xacro:counter_side parent="fridge_block"
       name="counter_side_fridge_left"
       pos_x="0" pos_y="0" pos_z="0.15"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.02" size_z="1.33"
     />
-    <counter_side parent="fridge_block"
+    <xacro:counter_side parent="fridge_block"
       name="counter_side_fridge_right"
       pos_x="0" pos_y="0.58" pos_z="0.15"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.02" size_z="1.33"
     />
 
-    <color_counter parent="fridge_block"
+    <xacro:color_counter parent="fridge_block"
       name="counter_bottom_fridge"
       pos_x="0" pos_y="0" pos_z="0.5"
       roll="0" pitch="0" yaw="0"
@@ -37,7 +37,7 @@
       material="KitchenWhite"
     />
 
-    <color_counter parent="fridge_block"
+    <xacro:color_counter parent="fridge_block"
       name="counter_middle_fridge"
       pos_x="0" pos_y="0" pos_z="0.83"
       roll="0" pitch="0" yaw="0"
@@ -45,19 +45,19 @@
       material="KitchenWhite"
     />
 
-    <drawer parent="fridge_block"
+    <xacro:drawer parent="fridge_block"
       name="drawer_fridge_bottom"
       pos_x="0.0" pos_y="0.0175" pos_z="0.15"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.565" size_z="0.365"
     />
-    <fridge parent="fridge_block"
+    <xacro:fridge parent="fridge_block"
       name="fridge"
       pos_x="0.0" pos_y="0" pos_z="0.51"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.6" size_z="0.97"
     />
-    <skirting parent="fridge_block"
+    <xacro:skirting parent="fridge_block"
       name="skirting_fridge"
       pos_x="0" pos_y="0" pos_z="0"
       roll="0" pitch="0" yaw="0"
@@ -72,7 +72,7 @@
   
     <link name="fridge_block_link">
 
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
 
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -82,6 +82,6 @@
       </visual>
     </link>
     
-  </macro>
+  </xacro:macro>
 
 </robot>

--- a/iai_kitchen_defs/defs/ias_kitchen/furniture_defs.xml
+++ b/iai_kitchen_defs/defs/ias_kitchen/furniture_defs.xml
@@ -7,15 +7,15 @@
   <xacro:include filename="$(find iai_kitchen_defs)/defs/util_defs.xml"/>
 <!--  <include filename="$(find iai_maps)/defs/ias_kitchen/materials.xml"/>-->
 
-  <property name="handle_thickness" value="0.015"/>
-  <property name="handle_offset" value="0.045"/>
-  <property name="handle_distance" value="0.055"/>
+  <xacro:property name="handle_thickness" value="0.015"/>
+  <xacro:property name="handle_offset" value="0.045"/>
+  <xacro:property name="handle_distance" value="0.055"/>
 
   <!--              -->
   <!-- Handle Macro -->
   <!--              -->
 
-  <macro name="handle" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z">
+  <xacro:macro name="handle" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z">
 
     <joint name="${parent}_${name}_joint" type="fixed">
       <origin rpy="${roll} ${pitch} ${yaw}" xyz="${pos_x+size_x/2} ${pos_y+size_y/2} ${pos_z+size_z/2}"/>
@@ -25,14 +25,14 @@
 
     <link name="${name}_link">
       
-      <cuboid_inertia width="${size_x - 0.005}" length="${size_y - 0.005}" height="${size_z - 0.005}" mass="0.1"/>
+      <xacro:cuboid_inertia width="${size_x - 0.005}" length="${size_y - 0.005}" height="${size_z - 0.005}" mass="0.1"/>
 
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
           <box size="${size_x - 0.005} ${size_y - 0.005} ${size_z - 0.005}"/>
         </geometry>
-	<material name="KitchenDarkGray"/>
+        <material name="KitchenDarkGray"/>
       </visual>
 
       <collision>
@@ -48,13 +48,13 @@
     </gazebo>
     
 
-  </macro>
+  </xacro:macro>
 
   <!--              -->
   <!-- Drawer Macro -->
   <!--              -->
 
-  <macro name="drawer" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z">
+  <xacro:macro name="drawer" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z">
     
     <joint name="${parent}_${name}_fixed_joint" type="fixed">
       <origin rpy="${roll} ${pitch} ${yaw}" xyz="${pos_x+size_x-0.01} ${pos_y+size_y/2} ${pos_z+size_z/2}"/>
@@ -63,7 +63,7 @@
     </joint>
 
     <link name="${name}_fixed_link">
-      <sphere_inertia radius="0.001" mass="1"/>
+      <xacro:sphere_inertia radius="0.001" mass="1"/>
     </link>
 
     <joint name="${parent}_${name}_joint" type="prismatic">
@@ -83,14 +83,14 @@
 
     <link name="${name}_link">
 
-      <cuboid_inertia width="0.02" length="${size_y}" height="${size_z}" mass="1.0"/>
+      <xacro:cuboid_inertia width="0.02" length="${size_y}" height="${size_z}" mass="1.0"/>
 
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
           <box size="0.02 ${size_y - 0.005} ${size_z - 0.005}"/>
         </geometry>
-	<material name="KitchenLightGray"/>
+        <material name="KitchenLightGray"/>
       </visual>
 
       <collision>
@@ -113,14 +113,14 @@
 
     <link name="${name}_left_link">
       
-      <cuboid_inertia width="${size_x - 0.04}" length="0.02" height="${size_z - 0.05}" mass="1.0" />
+      <xacro:cuboid_inertia width="${size_x - 0.04}" length="0.02" height="${size_z - 0.05}" mass="1.0" />
 
       <visual>
         <origin xyz="${-size_x/2 + 0.02} ${-size_y/2 + 0.02 + 0.04} 0" rpy="0 0 0"/>
         <geometry>
           <box size="${size_x - 0.04} 0.02 ${size_z - 0.05}"/>
         </geometry>
-	<material name="KitchenDarkGray"/>
+        <material name="KitchenDarkGray"/>
       </visual>
       <collision>
         <origin xyz="${-size_x/2 + 0.02} ${-size_y/2 + 0.02 + 0.04} 0" rpy="0 0 0"/>
@@ -142,14 +142,14 @@
 
     <link name="${name}_right_link">
       
-      <cuboid_inertia width="${size_x - 0.04}" length="0.02" height="${size_z - 0.05}" mass="1.0" />
+      <xacro:cuboid_inertia width="${size_x - 0.04}" length="0.02" height="${size_z - 0.05}" mass="1.0" />
       
       <visual>
         <origin xyz="${-size_x/2 + 0.02} ${size_y/2 - 0.02 - 0.04} 0" rpy="0 0 0"/>
         <geometry>
           <box size="${size_x - 0.04} 0.02 ${size_z - 0.05}"/>
         </geometry>
-	<material name="KitchenDarkGray"/>
+        <material name="KitchenDarkGray"/>
       </visual>
       <collision>
         <origin xyz="${-size_x/2 + 0.02} ${size_y/2 - 0.02 - 0.04} 0" rpy="0 0 0"/>
@@ -171,14 +171,14 @@
     
     <link name="${name}_back_link">
       
-      <cuboid_inertia width="0.02" length="${size_y - 0.04 - 0.04 - 0.02}" height="${size_z - 0.05}" mass="1.0" />
+      <xacro:cuboid_inertia width="0.02" length="${size_y - 0.04 - 0.04 - 0.02}" height="${size_z - 0.05}" mass="1.0" />
 
       <visual>
         <origin xyz="${-size_x + 0.04} 0 0" rpy="0 0 0"/>
         <geometry>
           <box size="0.02 ${size_y - 0.04 - 0.04 - 0.02} ${size_z - 0.05}"/>
         </geometry>
-	<material name="KitchenDarkGray"/>
+        <material name="KitchenDarkGray"/>
       </visual>
 
       <collision>
@@ -201,14 +201,14 @@
     
     <link name="${name}_bottom_link">
 
-      <cuboid_inertia width="${size_x - 0.04}" length="${size_y - 0.04 - 0.04 - 0.02}" height="0.02" mass="1.0" />
+      <xacro:cuboid_inertia width="${size_x - 0.04}" length="${size_y - 0.04 - 0.04 - 0.02}" height="0.02" mass="1.0" />
 
       <visual>
         <origin xyz="${-size_x/2+0.02} 0 ${-size_z/2 + 0.035}" rpy="0 0 0"/>
         <geometry>
           <box size="${size_x - 0.04} ${size_y - 0.04 - 0.04 - 0.02} 0.02"/>
         </geometry>
-	<material name="KitchenDarkGray"/>
+        <material name="KitchenDarkGray"/>
       </visual>
 
       <collision>
@@ -223,7 +223,7 @@
       <material value="Ias/KitchenLightGray" />
     </gazebo>
     
-    <handle
+    <xacro:handle
       name="handle_${name}"
       parent="${name}"
       roll="0" pitch="0" yaw="0"
@@ -233,13 +233,13 @@
       size_x="${handle_thickness}"
       size_y="${size_y - 2*handle_offset}"
       size_z="${handle_thickness}" />
-  </macro>
+  </xacro:macro>
 
   <!--                       -->
   <!-- Drawer Vertical Macro -->
   <!--                       -->
 
-  <macro name="drawer_vert" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z">
+  <xacro:macro name="drawer_vert" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z">
 
     <joint name="${parent}_${name}_fixed_joint" type="fixed">
       <origin rpy="${roll} ${pitch} ${yaw}" xyz="${pos_x+size_x/2} ${pos_y+size_y/2} ${pos_z+size_z/2}"/>
@@ -249,7 +249,7 @@
 
     <link name="${name}_fixed_link">
   
-      <sphere_inertia radius="0.001" mass="0.1"/>
+      <xacro:sphere_inertia radius="0.001" mass="0.1"/>
     
     </link>
 
@@ -263,7 +263,7 @@
 
     <link name="${name}_link">
 
-      <cuboid_inertia width="${size_x - 0.005}" length="${size_y - 0.005}" height="${size_z - 0.005}" mass="1.0"/>
+      <xacro:cuboid_inertia width="${size_x - 0.005}" length="${size_y - 0.005}" height="${size_z - 0.005}" mass="1.0"/>
 
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -285,7 +285,7 @@
       <material value="Ias/KitchenLightGray" />
     </gazebo>
     
-    <handle
+    <xacro:handle
       name="handle_${name}"
       parent="${name}"
       roll="0" pitch="0" yaw="0"
@@ -297,13 +297,13 @@
       size_z="${size_z - 2*handle_offset}"
     />
 
-  </macro>
+  </xacro:macro>
 
   <!--              -->
   <!-- Fridge Macro -->
   <!--              -->
 
-  <macro name="fridge" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z">
+  <xacro:macro name="fridge" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z">
 
     <joint name="${parent}_${name}_fixed_joint" type="fixed">
       <origin rpy="${roll} ${pitch} ${yaw}" xyz="${pos_x+size_x} ${pos_y+size_y} ${pos_z+size_z/2}"/>
@@ -313,7 +313,7 @@
 
     <link name="${name}_fixed_link">
 
-      <sphere_inertia radius="0.001" mass="0.1"/>
+      <xacro:sphere_inertia radius="0.001" mass="0.1"/>
     
     </link>
 
@@ -327,7 +327,7 @@
 
     <link name="${name}_link">
 
-      <cuboid_inertia width="${0.01 - 0.005}" length="${size_y - 0.005}" height="${size_z - 0.005}" mass="1.0"/>
+      <xacro:cuboid_inertia width="${0.01 - 0.005}" length="${size_y - 0.005}" height="${size_z - 0.005}" mass="1.0"/>
 
       <visual>
         <origin xyz="${-0.005} ${-size_y*0.5} 0" rpy="0 0 0"/>
@@ -361,13 +361,13 @@
       size_z="${size_z - 2*handle_offset}"
     />
 
-  </macro>
+  </xacro:macro>
 
   <!--               -->
   <!-- Counter Macro -->
   <!--               -->
 
-  <macro name="counter" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z">
+  <xacro:macro name="counter" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z">
 
     <joint name="${parent}_${name}_joint" type="fixed">
       <origin rpy="${roll} ${pitch} ${yaw}" xyz="${pos_x+size_x/2} ${pos_y+size_y/2} ${pos_z+size_z/2}"/>
@@ -377,14 +377,14 @@
 
     <link name="${name}_link">
 
-      <cuboid_inertia width="${size_x}" length="${size_y}" height="${size_z}" mass="2.0"/>
+      <xacro:cuboid_inertia width="${size_x}" length="${size_y}" height="${size_z}" mass="2.0"/>
 
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
           <box size="${size_x} ${size_y} ${size_z}"/>
         </geometry>
-	<material name="KitchenDarkGray"/>
+        <material name="KitchenDarkGray"/>
       </visual>
 
       <collision>
@@ -403,13 +403,13 @@
       <material value="Ias/KitchenDarkGray" />
     </gazebo>
   
-  </macro>
+  </xacro:macro>
   
   <!--                     -->
   <!-- Color Counter Macro -->
   <!--                     -->
 
-  <macro name="color_counter" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z material">
+  <xacro:macro name="color_counter" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z material">
 
     <joint name="${parent}_${name}_joint" type="fixed">
       <origin rpy="${roll} ${pitch} ${yaw}" xyz="${pos_x+size_x/2} ${pos_y+size_y/2} ${pos_z+size_z/2}"/>
@@ -419,7 +419,7 @@
 
     <link name="${name}_link">
 
-      <cuboid_inertia width="${size_x}" length="${size_y}" height="${size_z}" mass="2.0"/>
+      <xacro:cuboid_inertia width="${size_x}" length="${size_y}" height="${size_z}" mass="2.0"/>
 
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -445,13 +445,13 @@
       <material value="Ias/${material}" />
     </gazebo>
   
-  </macro>
+  </xacro:macro>
 
   <!--                    -->
   <!-- Counter Side Macro -->
   <!--                    -->
 
-  <macro name="counter_side" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z">
+  <xacro:macro name="counter_side" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z">
 
     <joint name="${parent}_${name}_joint" type="fixed">
       <origin rpy="${roll} ${pitch} ${yaw}" xyz="${pos_x+size_x/2} ${pos_y+size_y/2} ${pos_z+size_z/2}"/>
@@ -461,14 +461,14 @@
 
     <link name="${name}_link">
       
-      <cuboid_inertia width="${size_x}" length="${size_y}" height="${size_z}" mass="2.0"/>
+      <xacro:cuboid_inertia width="${size_x}" length="${size_y}" height="${size_z}" mass="2.0"/>
       
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
           <box size="${size_x} ${size_y} ${size_z}"/>
         </geometry>
-	<material name="KitchenDarkGray"/>
+        <material name="KitchenDarkGray"/>
       </visual>
 
       <collision>
@@ -483,13 +483,13 @@
       <material value="Ias/KitchenDarkGray" />
     </gazebo>
   
-  </macro>
+  </xacro:macro>
 
   <!--             -->
   <!-- Rack Macro -->
   <!--             -->
 
-  <macro name="rack" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z">
+  <xacro:macro name="rack" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z">
 
     <joint name="${parent}_${name}_joint" type="fixed">
       <origin rpy="${roll} ${pitch} ${yaw}" xyz="${pos_x+size_x/2} ${pos_y+size_y/2} ${pos_z+size_z/2}"/>
@@ -499,14 +499,14 @@
 
     <link name="${name}_link">
 
-      <cuboid_inertia width="${size_x}" length="${size_y}" height="${size_z}" mass="${size_x*size_y*size_z}"/>
+      <xacro:cuboid_inertia width="${size_x}" length="${size_y}" height="${size_z}" mass="${size_x*size_y*size_z}"/>
   
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
           <box size="${size_x} ${size_y} ${size_z}"/>
         </geometry>
-	<material name="KitchenDarkGray"/>
+        <material name="KitchenDarkGray"/>
       </visual>
 
       <collision>
@@ -521,13 +521,13 @@
       <material value="Ias/KitchenLightGray" />
     </gazebo>
 
-  </macro>
+  </xacro:macro>
 
   <!--                 -->
   <!-- Rack Side Macro -->
   <!--                 -->
 
-  <macro name="rack_side" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z">
+  <xacro:macro name="rack_side" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z">
 
     <joint name="${parent}_${name}_joint" type="fixed">
       <origin rpy="${roll} ${pitch} ${yaw}" xyz="${pos_x+size_x/2} ${pos_y+size_y/2} ${pos_z+size_z/2}"/>
@@ -537,14 +537,14 @@
 
     <link name="${name}_link">
 
-      <cuboid_inertia width="${size_x}" length="${size_y}" height="${size_z}" mass="${size_x*size_y*size_z}"/>
+      <xacro:cuboid_inertia width="${size_x}" length="${size_y}" height="${size_z}" mass="${size_x*size_y*size_z}"/>
       
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
           <box size="${size_x} ${size_y} ${size_z}"/>
         </geometry>
-	<material name="KitchenDarkGray"/>
+        <material name="KitchenDarkGray"/>
       </visual>
 
       <collision>
@@ -559,13 +559,13 @@
       <material value="Ias/KitchenDarkGray" />
     </gazebo>
   
-  </macro>
+  </xacro:macro>
 
   <!--                -->
   <!-- Skirting Macro -->
   <!--                -->
 
-  <macro name="skirting" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z">
+  <xacro:macro name="skirting" params="parent name pos_x pos_y pos_z roll pitch yaw size_x size_y size_z">
 
     <joint name="${parent}_${name}_joint" type="fixed">
       <origin rpy="${roll} ${pitch} ${yaw}" xyz="${pos_x+size_x/2} ${pos_y+size_y/2} ${pos_z+size_z/2}"/>
@@ -575,14 +575,14 @@
 
     <link name="${name}_link">
 
-      <cuboid_inertia width="${size_x}" length="${size_y}" height="${size_z}" mass="10"/>
+      <xacro:cuboid_inertia width="${size_x}" length="${size_y}" height="${size_z}" mass="10"/>
       
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
         <geometry>
           <box size="${size_x} ${size_y} ${size_z}"/>
         </geometry>
-	<material name="KitchenDarkGray"/>
+        <material name="KitchenDarkGray"/>
       </visual>
 
       <collision>
@@ -597,6 +597,6 @@
       <material value="Ias/KitchenDarkGray" />
     </gazebo>
 
-  </macro>
+  </xacro:macro>
 
 </robot>

--- a/iai_kitchen_defs/defs/ias_kitchen/island_block.xml
+++ b/iai_kitchen_defs/defs/ias_kitchen/island_block.xml
@@ -18,7 +18,7 @@
 
     <link name="stove_link">
 
-      <cuboid_inertia width="0.5" length="0.57" height="0.005" mass="1.0"/>
+      <xacro:cuboid_inertia width="0.5" length="0.57" height="0.005" mass="1.0"/>
 
       <visual>
         <origin xyz=".30 1.895 .8525" rpy="0 0 0"/>

--- a/iai_kitchen_defs/defs/ias_kitchen/island_block.xml
+++ b/iai_kitchen_defs/defs/ias_kitchen/island_block.xml
@@ -8,7 +8,7 @@
   <!-- Island Area -->
   <!--             -->
 
-  <macro name="island_block" params="block_pos block_rpy">
+  <xacro:macro name="island_block" params="block_pos block_rpy">
 
     <joint name="island_block_stove_joint" type="fixed">
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -25,7 +25,7 @@
         <geometry>
           <box size=".50 .57 0.005"/>
         </geometry>
-	<material name="KitchenStove"/>
+        <material name="KitchenStove"/>
       </visual>
 
       <collision>
@@ -40,92 +40,92 @@
       <material value="Ias/KitchenStove" />
     </gazebo>
 
-    <counter_side parent="island_block"
+    <xacro:counter_side parent="island_block"
       name="counter_side_island_left"
       pos_x="0" pos_y="0" pos_z="0"
       roll="0" pitch="0" yaw="0"
       size_x="0.60" size_y="0.03" size_z="0.82"
     />
-    <counter_side parent="island_block"
+    <xacro:counter_side parent="island_block"
       name="counter_side_island_right"
       pos_x="0" pos_y="2.23" pos_z="0"
       roll="0" pitch="0" yaw="0"
       size_x="0.60" size_y="0.03" size_z="0.82"
     />
-    <counter_side parent="island_block"
+    <xacro:counter_side parent="island_block"
       name="counter_side_island_back"
       pos_x="0" pos_y="0.03" pos_z="0"
       roll="0" pitch="0" yaw="0"
       size_x="0.02" size_y="2.2" size_z="0.82"
     />
-    <counter parent="island_block"
+    <xacro:counter parent="island_block"
       name="counter_top_island"
       pos_x="-0.1" pos_y="-0.1" pos_z="0.82"
       roll="0" pitch="0" yaw="0"
       size_x="0.80" size_y="2.45" size_z="0.03"
     />
-    <color_counter parent="island_block"
+    <xacro:color_counter parent="island_block"
       name="white_counter_top_island"
       pos_x="-0.1" pos_y="-0.1" pos_z="0.85"
       roll="0" pitch="0" yaw="0"
       size_x="0.80" size_y="2.45" size_z="0.002"
       material="KitchenWhite"
     />
-    <drawer parent="island_block"
+    <xacro:drawer parent="island_block"
       name="drawer_island_col1_bottom"
       pos_x="0" pos_y="0.03" pos_z="0.1"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.6" size_z="0.29"
     />
-    <drawer parent="island_block"
+    <xacro:drawer parent="island_block"
       name="drawer_island_col1_center"
       pos_x="0" pos_y="0.03" pos_z="0.39"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.6" size_z="0.29"
     />
-    <drawer parent="island_block"
+    <xacro:drawer parent="island_block"
       name="drawer_island_col1_top"
       pos_x="0" pos_y="0.03" pos_z="0.68"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.6" size_z="0.14"
     />
-    <drawer parent="island_block"
+    <xacro:drawer parent="island_block"
       name="drawer_island_col2_bottom"
       pos_x="0" pos_y="0.63" pos_z="0.1"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="1.0" size_z="0.29"
     />
-    <drawer parent="island_block"
+    <xacro:drawer parent="island_block"
       name="drawer_island_col2_center"
       pos_x="0" pos_y="0.63" pos_z="0.39"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="1.0" size_z="0.29"
     />
-    <drawer parent="island_block"
+    <xacro:drawer parent="island_block"
       name="drawer_island_col2_top"
       pos_x="0" pos_y="0.63" pos_z="0.68"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="1.0" size_z="0.14"
     />
-    <drawer parent="island_block"
+    <xacro:drawer parent="island_block"
       name="drawer_island_col3_bottom"
       pos_x="0" pos_y="1.63" pos_z="0.1"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.6" size_z="0.29"
     />
-    <drawer parent="island_block"
+    <xacro:drawer parent="island_block"
       name="drawer_island_col3_center"
       pos_x="0" pos_y="1.63" pos_z="0.39"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.6" size_z="0.29"
     />
-    <drawer parent="island_block"
+    <xacro:drawer parent="island_block"
       name="drawer_island_col3_top"
       pos_x="0" pos_y="1.63" pos_z="0.68"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.6" size_z="0.14"
       />
-    <skirting parent="island_block"
+    <xacro:skirting parent="island_block"
       name="skirting_island"
       pos_x="0.02" pos_y="0.03" pos_z="0"
       roll="0" pitch="0" yaw="0"
@@ -140,7 +140,7 @@
   
     <link name="island_block_link">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
 
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -150,6 +150,6 @@
       </visual>
     </link>
 
-  </macro>
+  </xacro:macro>
   
 </robot>

--- a/iai_kitchen_defs/defs/ias_kitchen/oven_block.xml
+++ b/iai_kitchen_defs/defs/ias_kitchen/oven_block.xml
@@ -8,45 +8,45 @@
   <!-- Oven Area -->
   <!--           -->
 
-  <macro name="oven_block" params="block_pos block_rpy">
+  <xacro:macro name="oven_block" params="block_pos block_rpy">
   
-    <counter parent="oven_block"
+    <xacro:counter parent="oven_block"
       name="counter_top_oven"
       pos_x="0" pos_y="0" pos_z="1.48"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="1.2" size_z="0.03"
     />
-    <drawer_vert parent="oven_block"
+    <xacro:drawer_vert parent="oven_block"
       name="drawer_oven_left"
       pos_x="0" pos_y="0" pos_z="0.15"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.30" size_z="1.33"
     />
-    <drawer parent="oven_block"
+    <xacro:drawer parent="oven_block"
       name="drawer_oven_bottom"
       pos_x="0.0" pos_y="0.3" pos_z="0.15"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.6" size_z="0.58"
     />
-    <drawer parent="oven_block"
+    <xacro:drawer parent="oven_block"
       name="drawer_oven_center"
       pos_x="0.0" pos_y="0.3" pos_z="0.73"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.6" size_z="0.14"
     />
-    <drawer parent="oven_block"
+    <xacro:drawer parent="oven_block"
       name="drawer_oven_oven"
       pos_x="0.0" pos_y="0.3" pos_z="0.86"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.6" size_z="0.62"
     />
-    <drawer_vert parent="oven_block"
+    <xacro:drawer_vert parent="oven_block"
       name="drawer_oven_right"
       pos_x="0.0" pos_y="0.9" pos_z="0.15"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.30" size_z="1.33"
     />
-    <skirting parent="oven_block"
+    <xacro:skirting parent="oven_block"
       name="skirting_oven"
       pos_x="0" pos_y="0" pos_z="0"
       roll="0" pitch="0" yaw="0"
@@ -61,7 +61,7 @@
   
     <link name="oven_block_link">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -71,6 +71,6 @@
       </visual>
     </link>
   
-  </macro>
+  </xacro:macro>
 
 </robot>

--- a/iai_kitchen_defs/defs/ias_kitchen/shopping_block.xml
+++ b/iai_kitchen_defs/defs/ias_kitchen/shopping_block.xml
@@ -8,33 +8,33 @@
   <!-- Shopping Area -->
   <!--               -->
 
-  <macro name="shopping_block" params="name parent block_pos block_rpy">
+  <xacro:macro name="shopping_block" params="name parent block_pos block_rpy">
 
-    <rack_side parent="${name}_shopping_block"
+    <xacro:rack_side parent="${name}_shopping_block"
       name="${name}_side_rack"
       pos_x="0" pos_y="0" pos_z="0"
       roll="0" pitch="0" yaw="0"
       size_x="0.090" size_y="1.270" size_z="1.600"
     />
-    <rack parent="${name}_shopping_block"
+    <xacro:rack parent="${name}_shopping_block"
       name="${name}_rack_skirting"
       pos_x="0.090" pos_y="0" pos_z="0"
       roll="0" pitch="0" yaw="0"
       size_x="${0.685 - 0.090}" size_y="1.270" size_z="0.150"
     />
-    <rack parent="${name}_shopping_block"
+    <xacro:rack parent="${name}_shopping_block"
       name="${name}_rack_bottom"
       pos_x="0.090" pos_y="0.010" pos_z="0.610"
       roll="0" pitch="0" yaw="0"
       size_x="${0.550 - 0.090}" size_y="1.250" size_z="0.030"
     />
-    <rack parent="${name}_shopping_block"
+    <xacro:rack parent="${name}_shopping_block"
       name="${name}_rack_middle"
       pos_x="0.090" pos_y="0.010" pos_z="1.090"
       roll="0" pitch="0" yaw="0"
       size_x="${0.550 - 0.090}" size_y="1.250" size_z="0.030"
     />
-    <rack parent="${name}_shopping_block"
+    <xacro:rack parent="${name}_shopping_block"
       name="${name}_rack_top"
       pos_x="0.090" pos_y="0.010" pos_z="1.570"
       roll="0" pitch="0" yaw="0"
@@ -56,7 +56,7 @@
 
     <link name="${name}_shopping_block_link">
 
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
     
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -66,6 +66,6 @@
       </visual>
     </link>
     
-  </macro>
+  </xacro:macro>
 
 </robot>

--- a/iai_kitchen_defs/defs/ias_kitchen/sink_block.xml
+++ b/iai_kitchen_defs/defs/ias_kitchen/sink_block.xml
@@ -4,7 +4,7 @@
        xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
        xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <macro name="sink_block" params="block_pos block_rpy">
+  <xacro:macro name="sink_block" params="block_pos block_rpy">
 
     <!--           -->
     <!-- Sink Area -->
@@ -18,14 +18,14 @@
 
     <link name="sink_link">
 
-      <cuboid_inertia width="0.5" length="0.86" height="0.005" mass="1.0"/>
+      <xacro:cuboid_inertia width="0.5" length="0.86" height="0.005" mass="1.0"/>
 
       <visual>
         <origin xyz=".295 1.485 .8525" rpy="0 0 0"/>
         <geometry>
           <box size=".50 .86 0.005"/>
         </geometry>
-	<material name="KitchenSink"/>
+        <material name="KitchenSink"/>
       </visual>
 
       <collision>
@@ -40,68 +40,68 @@
       <material value="Ias/KitchenSink" />
     </gazebo>
 
-    <counter_side parent="sink_block"
+    <xacro:counter_side parent="sink_block"
       name="counter_side_sink_left"
       pos_x="0" pos_y="0" pos_z="0"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.03" size_z="0.82"
     />
-    <counter_side parent="sink_block"
+    <xacro:counter_side parent="sink_block"
       name="counter_side_sink_right"
       pos_x="0" pos_y="2.03" pos_z="0"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.03" size_z="0.82"
     />
-    <counter parent="sink_block"
+    <xacro:counter parent="sink_block"
       name="counter_top_sink"
       pos_x="0" pos_y="0" pos_z="0.82"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="2.06" size_z="0.03"
     />
-    <color_counter parent="sink_block"
+    <xacro:color_counter parent="sink_block"
       name="white_counter_top_sink"
       pos_x="0" pos_y="0" pos_z="0.85"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="2.06" size_z="0.002"
       material="KitchenWhite"
     />
-    <drawer parent="sink_block"
+    <xacro:drawer parent="sink_block"
       name="drawer_sink_col1_bottom"
       pos_x="0" pos_y="0.03" pos_z="0.1"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.8" size_z="0.29"
     />
-    <drawer parent="sink_block"
+    <xacro:drawer parent="sink_block"
       name="drawer_sink_col1_center"
       pos_x="0" pos_y="0.03" pos_z="0.39"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.8" size_z="0.29"
     />
-    <drawer parent="sink_block"
+    <xacro:drawer parent="sink_block"
       name="drawer_sink_col1_top"
       pos_x="0" pos_y="0.03" pos_z="0.68"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.8" size_z="0.14"
     />
-    <drawer parent="sink_block"
+    <xacro:drawer parent="sink_block"
       name="drawer_sink_col2"
       pos_x="0" pos_y="0.83" pos_z="0.1"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.6" size_z="0.72"
     />
-    <drawer parent="sink_block"
+    <xacro:drawer parent="sink_block"
       name="drawer_sink_col3_bottom"
       pos_x="0" pos_y="1.43" pos_z="0.1"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.6" size_z="0.58"
     />
-    <drawer parent="sink_block"
+    <xacro:drawer parent="sink_block"
       name="drawer_sink_col3_top"
       pos_x="0" pos_y="1.43" pos_z="0.68"
       roll="0" pitch="0" yaw="0"
       size_x="0.58" size_y="0.6" size_z="0.14"
     />
-    <skirting parent="sink_block"
+    <xacro:skirting parent="sink_block"
       name="skirting_sink"
       pos_x="0" pos_y="0.03" pos_z="0"
       roll="0" pitch="0" yaw="0"
@@ -116,7 +116,7 @@
   
     <link name="sink_block_link">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -126,6 +126,6 @@
       </visual>
     </link>
   
-  </macro>
+  </xacro:macro>
 
 </robot>

--- a/iai_kitchen_defs/defs/ias_kitchen/small_table.xml
+++ b/iai_kitchen_defs/defs/ias_kitchen/small_table.xml
@@ -12,9 +12,9 @@
     <!-- Table -->
     <!--       -->
     
-    <macro name="small_table" params="name parent block_pos block_rpy material">
+    <xacro:macro name="small_table" params="name parent block_pos block_rpy material">
       
-      <color_counter parent="${name}_table"
+      <xacro:color_counter parent="${name}_table"
       name="${name}_table_top"
       pos_x="0" pos_y="0" pos_z="0.705"
       roll="0" pitch="0" yaw="0"
@@ -30,7 +30,7 @@
           
           <link name="${name}_first_leg_link">
             
-            <cylinder_inertia radius="0.025" length="0.7" mass="1.0"/>
+            <xacro:cylinder_inertia radius="0.025" length="0.7" mass="1.0"/>
             
             <visual>
               <origin xyz="0 0 0" rpy="0 0 0" />
@@ -58,7 +58,7 @@
           
           <link name="${name}_second_leg_link">
             
-            <cylinder_inertia radius="0.025" length="0.7" mass="1.0"/>
+            <xacro:cylinder_inertia radius="0.025" length="0.7" mass="1.0"/>
             
             <visual>
               <origin xyz="0 0 0" rpy="0 0 0" />
@@ -86,7 +86,7 @@
           
           <link name="${name}_third_leg_link">
             
-            <cylinder_inertia radius="0.025" length="0.7" mass="1.0"/>
+            <xacro:cylinder_inertia radius="0.025" length="0.7" mass="1.0"/>
             
             <visual>
               <origin xyz="0 0 0" rpy="0 0 0" />
@@ -114,7 +114,7 @@
           
           <link name="${name}_fourth_leg_link">
             
-            <cylinder_inertia radius="0.025" length="0.7" mass="1.0"/>
+            <xacro:cylinder_inertia radius="0.025" length="0.7" mass="1.0"/>
             
             <visual>
               <origin xyz="0 0 0" rpy="0 0 0" />
@@ -142,7 +142,7 @@
           
           <link name="${name}_table_link">
             
-            <sphere_inertia radius="0" mass="0"/>
+            <xacro:sphere_inertia radius="0" mass="0"/>
             
             <visual>
               <origin xyz="0 0 0" rpy="0 0 0" />
@@ -152,7 +152,7 @@
             </visual>
           </link>
           
-        </macro>
+        </xacro:macro>
         
       </robot>
       

--- a/iai_kitchen_defs/defs/ias_kitchen/table.xml
+++ b/iai_kitchen_defs/defs/ias_kitchen/table.xml
@@ -12,9 +12,9 @@
   <!-- Table -->
   <!--       -->
 
-  <macro name="table" params="name parent block_pos block_rpy material">
+  <xacro:macro name="table" params="name parent block_pos block_rpy material">
 
-    <color_counter parent="${name}_table"
+    <xacro:color_counter parent="${name}_table"
       name="${name}_table_top"
       pos_x="0" pos_y="0" pos_z="0.705"
       roll="0" pitch="0" yaw="0"
@@ -30,7 +30,7 @@
 
     <link name="${name}_first_leg_link">
 
-      <cylinder_inertia radius="0.025" length="0.7" mass="1.0"/>
+      <xacro:cylinder_inertia radius="0.025" length="0.7" mass="1.0"/>
 
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -58,7 +58,7 @@
 
     <link name="${name}_second_leg_link">
       
-      <cylinder_inertia radius="0.025" length="0.7" mass="1.0"/>
+      <xacro:cylinder_inertia radius="0.025" length="0.7" mass="1.0"/>
       
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -86,7 +86,7 @@
 
     <link name="${name}_third_leg_link">
       
-      <cylinder_inertia radius="0.025" length="0.7" mass="1.0"/>
+      <xacro:cylinder_inertia radius="0.025" length="0.7" mass="1.0"/>
       
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -114,7 +114,7 @@
 
     <link name="${name}_fourth_leg_link">
       
-      <cylinder_inertia radius="0.025" length="0.7" mass="1.0"/>
+      <xacro:cylinder_inertia radius="0.025" length="0.7" mass="1.0"/>
       
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -142,7 +142,7 @@
 
     <link name="${name}_table_link">
       
-      <sphere_inertia radius="0" mass="0"/>
+      <xacro:sphere_inertia radius="0" mass="0"/>
       
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -152,6 +152,6 @@
       </visual>
     </link>
 
-  </macro>
+  </xacro:macro>
 
 </robot>

--- a/iai_kitchen_defs/defs/util_defs.xml
+++ b/iai_kitchen_defs/defs/util_defs.xml
@@ -1,29 +1,30 @@
 <?xml version="1.0"?>
-<robot xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro"
+       xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor"
        xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
        xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface">
 
-  <property name="M_PI" value="3.1415926535897931"/>
+  <xacro:property name="M_PI" value="3.1415926535897931"/>
 
   <!-- Little helper macro to define the inertia matrix needed for links. -->
 
-  <macro name="cuboid_inertia_def" params="width height length mass">
-    <inertia ixx="${mass * (height * height + length * length) / 12)}"
-             iyy="${mass * (width * width + length * length) / 12)}"
-             izz="${mass * (width * width + height * height) / 12)}"
+  <xacro:macro name="cuboid_inertia_def" params="width height length mass">
+    <inertia ixx="${mass * (height * height + length * length) / 12}"
+             iyy="${mass * (width * width + length * length) / 12}"
+             izz="${mass * (width * width + height * height) / 12}"
              ixy="0" iyz="0" ixz="0"/>
-  </macro>
+  </xacro:macro>
 
   <!-- Length is along the y-axis. -->
 
-  <macro name="cylinder_inertia_def" params="radius length mass">
-    <inertia ixx="${mass * (3 * radius * radius + length * length) / 12)}"
-             iyy="${mass * radius * radius / 2)}"
-             izz="${mass * (3 * radius * radius + length * length) / 12)}"
+  <xacro:macro name="cylinder_inertia_def" params="radius length mass">
+    <inertia ixx="${mass * (3 * radius * radius + length * length) / 12}"
+             iyy="${mass * radius * radius / 2}"
+             izz="${mass * (3 * radius * radius + length * length) / 12}"
              ixy="0" iyz="0" ixz="0"/>
-  </macro>
+  </xacro:macro>
 
-  <macro name="sphere_inertia" params="radius mass">
+  <xacro:macro name="sphere_inertia" params="radius mass">
     <inertial>
       <mass value="${mass}"/>
       <inertia ixx="${(2*mass*radius*radius)/5}"
@@ -31,20 +32,20 @@
                izz="${(2*mass*radius*radius)/5}"
                ixy="0" iyz="0" ixz="0" />
       </inertial>
-  </macro>
+  </xacro:macro>
 
-  <macro name="cuboid_inertia" params="width height length mass">
+  <xacro:macro name="cuboid_inertia" params="width height length mass">
     <inertial>
       <mass value="${mass}"/>
-      <cuboid_inertia_def width="${width}" height="${height}" length="${length}" mass="${mass}"/>
+      <xacro:cuboid_inertia_def width="${width}" height="${height}" length="${length}" mass="${mass}"/>
     </inertial>
-  </macro>
+  </xacro:macro>
 
-  <macro name="cylinder_inertia" params="radius length mass">
+  <xacro:macro name="cylinder_inertia" params="radius length mass">
     <inertial>
       <mass value="${mass}"/>
-      <cylinder_inertia_def radius="${radius}" length="${length}" mass="${mass}"/>
+      <xacro:cylinder_inertia_def radius="${radius}" length="${length}" mass="${mass}"/>
     </inertial>
-  </macro>
+  </xacro:macro>
 
 </robot>

--- a/iai_kitchen_defs/package.xml
+++ b/iai_kitchen_defs/package.xml
@@ -3,7 +3,7 @@
   <version>1.0.0</version>
   <description>URDF description of the kitchen laboratory of the IAI in Bremen</description>
 
-  <maintainer email="winkler@cs.uni-bremen.de">Jan Winkler</maintainer>
+  <maintainer email="aniedz@cs.uni-bremen.de">Arthur Niedzwiecki</maintainer>
 
   <license>LGPL</license>
 

--- a/iai_kitchen_defs/room/allInOne.urdf.xml
+++ b/iai_kitchen_defs/room/allInOne.urdf.xml
@@ -2,6 +2,7 @@
 <robot name="room" xmlns:xacro="http://www.ros.org/wiki/xacro">
   
   <xacro:include filename="$(find iai_kitchen_defs)/defs/util_defs.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/room/lab_macros.xml"/>
   <xacro:include filename="$(find iai_kitchen_defs)/Media/models/cash_register.urdf.xml"/>
   <xacro:include filename="$(find iai_kitchen_defs)/Media/models/chair.urdf.xml"/>
   <xacro:include filename="$(find iai_kitchen_defs)/Media/models/cnc.urdf.xml"/>
@@ -9,207 +10,132 @@
   <xacro:include filename="$(find iai_kitchen_defs)/Media/models/glasses.urdf.xml"/>
   <xacro:include filename="$(find iai_kitchen_defs)/Media/models/wine_cooler.urdf.xml"/>
   
+  <link name="room_link">
+    <xacro:sphere_inertia radius="0.001" mass="1"/>
+  </link>
   
   <!-- west wall -->
   
-  <wall name="w_wall_right" xyz="2.785 4.99 1.25" sxyz="0.54 0.1 2.5" material="Gazebo/White"/>
-  <wall name="w_wall_right_window" xyz="1.415 4.99 0.2925" sxyz="2.2 0.1 0.585" material="Gazebo/White"/>
-  <wall name="w_window_right" xyz="1.415 4.99 1.5425" sxyz="2.2 0.1 1.915" material="Gazebo/BlueTransparent"/>
-  <wall name="w_wall_center" xyz="0.025 4.99 1.25" sxyz="0.58 0.1 2.5" material="Gazebo/White"/>
-  <wall name="w_wall_center_window" xyz="-1.365 4.99 0.2925" sxyz="2.2 0.1 0.585" material="Gazebo/White"/>
-  <wall name="w_window_center" xyz="-1.365 4.99 1.5425" sxyz="2.2 0.1 1.915" material="Gazebo/BlueTransparent"/>
-  <wall name="w_wall_left" xyz="-3.07025 4.99 1.25" sxyz="1.215 0.1 2.5" material="Custom/acat"/>
-  <wall name="w_wall_left_window" xyz="-4.263 4.99 0.075" sxyz="1.175 0.1 0.15" material="Gazebo/White"/>
-  <wall name="w_window_left" xyz="-4.263 4.99 1.325" sxyz="1.175 0.1 2.35" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="w_wall_right" parent="room" xyz="2.785 4.99 1.25" sxyz="0.54 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="w_wall_right_window" parent="room" xyz="1.415 4.99 0.2925" sxyz="2.2 0.1 0.585" material="Gazebo/White"/>
+  <xacro:wall name="w_window_right" parent="room" xyz="1.415 4.99 1.5425" sxyz="2.2 0.1 1.915" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="w_wall_center" parent="room" xyz="0.025 4.99 1.25" sxyz="0.58 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="w_wall_center_window" parent="room" xyz="-1.365 4.99 0.2925" sxyz="2.2 0.1 0.585" material="Gazebo/White"/>
+  <xacro:wall name="w_window_center" parent="room" xyz="-1.365 4.99 1.5425" sxyz="2.2 0.1 1.915" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="w_wall_left" parent="room" xyz="-3.07025 4.99 1.25" sxyz="1.215 0.1 2.5" material="Custom/acat"/>
+  <xacro:wall name="w_wall_left_window" parent="room" xyz="-4.263 4.99 0.075" sxyz="1.175 0.1 0.15" material="Gazebo/White"/>
+  <xacro:wall name="w_window_left" parent="room" xyz="-4.263 4.99 1.325" sxyz="1.175 0.1 2.35" material="Gazebo/BlueTransparent"/>
   
   
   <!-- east wall -->
   
-  <wall name="e_wall_right" xyz="-5.2605 -7.08 1.25" sxyz="0.21 0.1 2.5" material="Gazebo/White"/>
-  <wall name="e_wall_right_window" xyz="-4.0705 -7.08 0.2925" sxyz="2.17 0.1 0.585" material="Gazebo/White"/>
-  <wall name="e_window_right" xyz="-4.0705 -7.08 1.5425" sxyz="2.17 0.1 1.915" material="Gazebo/BlueTransparent"/>
-  <wall name="e_wall_center_right" xyz="-2.6955 -7.08 1.25" sxyz="0.58 0.1 2.5" material="Custom/robohow"/>
-  <wall name="e_wall_center_window" xyz="-1.3205 -7.08 0.2925" sxyz="2.17 0.1 0.585" material="Gazebo/White"/>
-  <wall name="e_window_center" xyz="-1.3205 -7.08 1.5425" sxyz="2.17 0.1 1.915" material="Gazebo/BlueTransparent"/>
-  <wall name="e_wall_center_left" xyz="0.0545 -7.08 1.25" sxyz="0.58 0.1 2.5" material="Custom/roboearth2"/>
-  <wall name="e_wall_left_window" xyz="1.4395 -7.08 0.2925" sxyz="2.19 0.1 0.585" material="Gazebo/White"/>
-  <wall name="e_window_left" xyz="1.4395 -7.08 1.5425" sxyz="2.19 0.1 1.915" material="Gazebo/BlueTransparent"/>  
-  <wall name="e_wall_left" xyz="2.8 -7.08 1.25" sxyz="0.531 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="e_wall_right" parent="room" xyz="-5.2605 -7.08 1.25" sxyz="0.21 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="e_wall_right_window" parent="room" xyz="-4.0705 -7.08 0.2925" sxyz="2.17 0.1 0.585" material="Gazebo/White"/>
+  <xacro:wall name="e_window_right" parent="room" xyz="-4.0705 -7.08 1.5425" sxyz="2.17 0.1 1.915" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="e_wall_center_right" parent="room" xyz="-2.6955 -7.08 1.25" sxyz="0.58 0.1 2.5" material="Custom/robohow"/>
+  <xacro:wall name="e_wall_center_window" parent="room" xyz="-1.3205 -7.08 0.2925" sxyz="2.17 0.1 0.585" material="Gazebo/White"/>
+  <xacro:wall name="e_window_center" parent="room" xyz="-1.3205 -7.08 1.5425" sxyz="2.17 0.1 1.915" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="e_wall_center_left" parent="room" xyz="0.0545 -7.08 1.25" sxyz="0.58 0.1 2.5" material="Custom/roboearth2"/>
+  <xacro:wall name="e_wall_left_window" parent="room" xyz="1.4395 -7.08 0.2925" sxyz="2.19 0.1 0.585" material="Gazebo/White"/>
+  <xacro:wall name="e_window_left" parent="room" xyz="1.4395 -7.08 1.5425" sxyz="2.19 0.1 1.915" material="Gazebo/BlueTransparent"/>  
+  <xacro:wall name="e_wall_left" parent="room" xyz="2.8 -7.08 1.25" sxyz="0.531 0.1 2.5" material="Gazebo/White"/>
   
   
   <!-- north wall (left room) -->
   
-  <wall name="n_l_wall_right" xyz="3.90 -0.055 1.25" sxyz="0.1 0.94 2.5" material="Custom/logos"/>
-  <wall name="n_l_wall_center_window" xyz="3.90 1.705 0.075" sxyz="0.1 2.58 0.15" material="Gazebo/White"/>
-  <wall name="n_l_window_center" xyz="3.90 1.705 1.325" sxyz="0.1 2.58 2.35" material="Gazebo/BlueTransparent"/>
-  <wall name="n_l_wall_left" xyz="3.90 3.57 1.25" sxyz="0.1 1.15 2.5" material="Custom/saphari"/>
+  <xacro:wall name="n_l_wall_right" parent="room" xyz="3.90 -0.055 1.25" sxyz="0.1 0.94 2.5" material="Custom/logos"/>
+  <xacro:wall name="n_l_wall_center_window" parent="room" xyz="3.90 1.705 0.075" sxyz="0.1 2.58 0.15" material="Gazebo/White"/>
+  <xacro:wall name="n_l_window_center" parent="room" xyz="3.90 1.705 1.325" sxyz="0.1 2.58 2.35" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="n_l_wall_left" parent="room" xyz="3.90 3.57 1.25" sxyz="0.1 1.15 2.5" material="Custom/saphari"/>
   
   
   
   <!-- north wall (right room) -->
   
-  <wall name="n_r_wall_right" xyz="3.90 -3.985 1.25" sxyz="0.1 4.5 2.5" material="Custom/unihb_tum"/>
-  <wall name="n_r_wall_center_window" xyz="3.90 -1.13 0.075" sxyz="0.1 1.21 0.15" material="Gazebo/White"/>
-  <wall name="n_r_window_center" xyz="3.90 -1.13 1.325" sxyz="0.1 1.21 2.35" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="n_r_wall_right" parent="room" xyz="3.90 -3.985 1.25" sxyz="0.1 4.5 2.5" material="Custom/unihb_tum"/>
+  <xacro:wall name="n_r_wall_center_window" parent="room" xyz="3.90 -1.13 0.075" sxyz="0.1 1.21 0.15" material="Gazebo/White"/>
+  <xacro:wall name="n_r_window_center" parent="room" xyz="3.90 -1.13 1.325" sxyz="0.1 1.21 2.35" material="Gazebo/BlueTransparent"/>
 
   
   
   <!-- south wall (left room) -->
   
-  <wall name="s_l_wall_right" xyz="-4.9005 4.13 1.25" sxyz="0.1 1.82 2.5" material="Gazebo/White"/>
-  <wall name="s_l_wall_v_right" xyz="-5.1655 3.27 1.25" sxyz="0.43 0.1 2.5" material="Gazebo/White"/>
-  <wall name="s_l_wall_door_right" xyz="-5.3305 3.08 1.25" sxyz="0.1 0.28 2.5" material="Gazebo/White"/>
-  <wall name="s_l_wall_door_left" xyz="-5.3305 1.74 1.25" sxyz="0.1 0.28 2.5" material="Gazebo/White"/>
-  <wall name="s_l_wall_v_left" xyz="-4.8655 1.55 1.25" sxyz="1.0 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="s_l_wall_right" parent="room" xyz="-4.9005 4.13 1.25" sxyz="0.1 1.82 2.5" material="Gazebo/White"/>
+  <xacro:wall name="s_l_wall_v_right" parent="room" xyz="-5.1655 3.27 1.25" sxyz="0.43 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="s_l_wall_door_right" parent="room" xyz="-5.3305 3.08 1.25" sxyz="0.1 0.28 2.5" material="Gazebo/White"/>
+  <xacro:wall name="s_l_wall_door_left" parent="room" xyz="-5.3305 1.74 1.25" sxyz="0.1 0.28 2.5" material="Gazebo/White"/>
+  <xacro:wall name="s_l_wall_v_left" parent="room" xyz="-4.8655 1.55 1.25" sxyz="1.0 0.1 2.5" material="Gazebo/White"/>
   
-  <wall name="s_l_wall_left" xyz="-4.3155 0.545 1.25" sxyz="0.1 2.11 2.5" material="Gazebo/White"/>
+  <xacro:wall name="s_l_wall_left" parent="room" xyz="-4.3155 0.545 1.25" sxyz="0.1 2.11 2.5" material="Gazebo/White"/>
 
   <!-- south wall (right room) -->
-  <wall name="wall_door_left" xyz="-4.3155 -1.9 1.25" sxyz="0.1 0.42 2.5" material="Gazebo/White"/>
-  <wall name="wall_v" xyz="-4.8655 -2.06 1.25" sxyz="1.0 0.1 2.5" material="Gazebo/White"/>
-  <wall name="wall_left" xyz="-5.3155 -4.57 1.25" sxyz="0.1 4.92 2.5" material="Gazebo/White"/>
+  <xacro:wall name="wall_door_left" parent="room" xyz="-4.3155 -1.9 1.25" sxyz="0.1 0.42 2.5" material="Gazebo/White"/>
+  <xacro:wall name="wall_v" parent="room" xyz="-4.8655 -2.06 1.25" sxyz="1.0 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="wall_left" parent="room" xyz="-5.3155 -4.57 1.25" sxyz="0.1 4.92 2.5" material="Gazebo/White"/>
   
   
   <!-- pillars -->
   
-  <pillar name="small_pillar" xyz="0 -0.3 1.25" r="0.15" />
-  <pillar name="large_pillar_1" xyz="3.85 -7.03 1.25" r="0.795" />
-  <pillar name="large_pillar_2" xyz="3.85 4.94 1.25" r="0.795" />
+  <xacro:pillar name="small_pillar" parent="room" xyz="0 -0.3 1.25" radius="0.15" length="2.5"/>
+  <xacro:pillar name="large_pillar_1" parent="room" xyz="3.85 -7.03 1.25" radius="0.795" length="2.5"/>
+  <xacro:pillar name="large_pillar_2" parent="room" xyz="3.85 4.94 1.25" radius="0.795" length="2.5"/>
   
   
   <!-- partition walls -->
   
-  <wall name="partition_wall_work1" xyz="-2.1 -0.3 0.5" sxyz="4.4 0.1 1" material="Gazebo/White"/>
-  <wall name="partition_wall_work2" xyz="0 -1 0.5" sxyz="0.1 1.5 1" material="Gazebo/White"/>
+  <xacro:wall name="partition_wall_work1" parent="room" xyz="-2.1 -0.3 0.5" sxyz="4.4 0.1 1" material="Gazebo/White"/>
+  <xacro:wall name="partition_wall_work2" parent="room" xyz="0 -1 0.5" sxyz="0.1 1.5 1" material="Gazebo/White"/>
   
-  <wall name="partition_wall_shop" xyz="-0.25 -5 0.5" sxyz="0.1 4 1" material="Gazebo/White"/>
+  <xacro:wall name="partition_wall_shop" parent="room" xyz="-0.25 -5 0.5" sxyz="0.1 4 1" material="Gazebo/White"/>
  
   
   <!-- ground -->
   
-  <wall name="boden_kitchen" xyz="-2.65 -3.7 0.0005" sxyz="5.3 6.8 00.001" material="Ground/Blue"/>
-  <wall name="boden_shop" xyz="1.95 -4 0.0005" sxyz="3.9 6 00.001" material="Ground/Yellow"/>
-  <wall name="boden_mech" xyz="1.95 2 0.0005" sxyz="3.9 6 00.001" material="Ground/Red"/>
-  <wall name="boden_bio" xyz="-2.65 2.35 0.0005" sxyz="5.3 5.3 00.001" material="Ground/Green"/>
-  
-  
-  
-  <link name="room_link">
-    <sphere_inertia radius="0.001" mass="1"/>
-  </link>
-  
-  <!-- macro for walls -->
-  <macro name="wall" params="name xyz sxyz material">
-    
-    <joint name="${name}_joint" type="fixed">
-      <origin rpy="0 0 0" xyz="${xyz}"/>
-      <parent link="room_link"/>
-      <child link="${name}_link"/>
-    </joint>
-    
-    <link name="${name}_link">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <box size="${sxyz}"/>
-        </geometry>
-      </visual>      
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <box size="${sxyz}"/>
-        </geometry> 
-      </collision>
-      <inertial>
-        <mass value="1000" />
-        <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0" />
-      </inertial>
-    </link>    
-    <gazebo reference="${name}_link">
-      <static>true</static>
-      <material>${material}</material>
-    </gazebo>
-  </macro>
-  
-  
-  <!-- macro for pillars -->
-  <macro name="pillar" params="name xyz r">
-    
-    <joint name="${name}_joint" type="fixed">
-      <origin rpy="0 0 0" xyz="${xyz}"/>
-      <parent link="room_link"/>
-      <child link="${name}_link"/>
-    </joint>
-    
-    <link name="${name}_link">  
-      <visual>
-        <geometry>
-          <cylinder length="2.5" radius="${r}"/>
-        </geometry>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
-      </visual>
-      <collision>
-        <geometry>
-          <cylinder length="2.5" radius="${r}"/>
-        </geometry>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
-      </collision>
-      <inertial>
-        <mass value="1000" />
-        <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0" />
-      </inertial>
-    </link>
-    <gazebo reference="${name}_link">
-      <static>true</static>
-    </gazebo>
-  </macro>
+  <xacro:wall name="boden_kitchen" parent="room" xyz="-2.65 -3.7 0.0005" sxyz="5.3 6.8 00.001" material="Ground/Blue"/>
+  <xacro:wall name="boden_shop" parent="room" xyz="1.95 -4 0.0005" sxyz="3.9 6 00.001" material="Ground/Yellow"/>
+  <xacro:wall name="boden_mech" parent="room" xyz="1.95 2 0.0005" sxyz="3.9 6 00.001" material="Ground/Red"/>
+  <xacro:wall name="boden_bio" parent="room" xyz="-2.65 2.35 0.0005" sxyz="5.3 5.3 00.001" material="Ground/Green"/>
   
   <gazebo>
     <static>true</static>
   </gazebo>
-      
-      
-      
-      
-      
-  
-  
+
   
   <!--         -->
   <!-- Kitchen -->
   <!--         -->
   
   
-  <include filename="$(find iai_maps)/defs/ias_kitchen/furniture_defs.xml"/>
-  <include filename="$(find iai_maps)/defs/ias_kitchen/island_block.xml"/>
-  <include filename="$(find iai_maps)/defs/ias_kitchen/oven_block.xml"/>
-  <include filename="$(find iai_maps)/defs/ias_kitchen/fridge_block.xml"/>
-  <include filename="$(find iai_maps)/defs/ias_kitchen/sink_block.xml"/>
-  <include filename="$(find iai_maps)/defs/ias_kitchen/shopping_block.xml"/>
-  <include filename="$(find iai_maps)/defs/ias_kitchen/table.xml"/>
-  <include filename="$(find iai_maps)/defs/ias_kitchen/small_table.xml"/>
-  <include filename="$(find iai_maps)/defs/ias_kitchen/cuboid.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/furniture_defs.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/island_block.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/oven_block.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/fridge_block.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/sink_block.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/shopping_block.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/table.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/small_table.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/cuboid.xml"/>
   
   
   <!-- This is the top level joint /tf frame. -->
   <link name="kitchen_link">
-    <sphere_inertia radius="0.001" mass="1"/>
+    <xacro:sphere_inertia radius="0.001" mass="1"/>
   </link>
-  
+
   <!-- Shelves on top of kitchen counter -->
-  <counter parent="kitchen"
+  <xacro:counter parent="kitchen"
   name="shelf_bottom"
   pos_x="-5.22" pos_y="-5.65" pos_z="0.85"
   roll="0" pitch="0" yaw="0"
   size_x="0.25" size_y="0.38" size_z="0.025"
   />
-  <counter parent="kitchen"
+  <xacro:counter parent="kitchen"
   name="shelf_center"
   pos_x="-5.22" pos_y="-5.65" pos_z="1.15"
   roll="0" pitch="0" yaw="0"
   size_x="0.21" size_y="0.38" size_z="0.025"
   />
-  <counter parent="kitchen"
+  <xacro:counter parent="kitchen"
   name="shelf_top"
   pos_x="-5.22" pos_y="-5.65" pos_z="1.48"
   roll="0" pitch="0" yaw="0"
@@ -217,36 +143,36 @@
   />
 
   <!-- Finally, the 5 main blocks of the kitchen -->
-  <island_block block_pos="-1.50 -4.35 0" block_rpy="0 0 3.141"/>
+  <xacro:island_block block_pos="-1.50 -4.35 0" block_rpy="0 0 3.141"/>
   
-  <oven_block block_pos="-5.22 -6.85 0" block_rpy="0 0 0"/>
+  <xacro:oven_block block_pos="-5.22 -6.85 0" block_rpy="0 0 0"/>
   
-  <sink_block block_pos="-5.01 -5.65 0" block_rpy="0 0 0"/>
+  <xacro:sink_block block_pos="-5.01 -5.65 0" block_rpy="0 0 0"/>
   
-  <fridge_block block_pos="-5.125 -3.59 0" block_rpy="0 0 0"/>
-  
-  
+  <xacro:fridge_block block_pos="-5.125 -3.59 0" block_rpy="0 0 0"/>
   
   
-  <shopping_block name="left_shopping_block" parent="kitchen" block_pos="3.8 -4.1 0" block_rpy="0 0 3.141"/>
+  
+  
+  <xacro:shopping_block name="left_shopping_block" parent="kitchen" block_pos="3.8 -4.1 0" block_rpy="0 0 3.141"/>
   <!---x 5 -y -2.5 -z 0.0 -R 0 -P 0.0 -Y 3.9265-->
-  <wine_cooler name="cooler" parent="kitchen" xyz="3.0 -5.5 0" rpy="0 0 3.9265"/>
+  <xacro:wine_cooler name="cooler" parent="kitchen" xyz="3.0 -5.5 0" rpy="0 0 3.9265"/>
   
-  <shopping_block name="right_shopping_block" parent="kitchen" block_pos="2.2 -6.97 0" block_rpy="0 0 1.57"/>
-  
-  
-  <table name="cash1" parent="kitchen" block_pos="1.52 -5 0" block_rpy="0 0 1.57" material="KitchenWhite"/>
-  <small_table name="cash2" parent="kitchen" block_pos="0.9 -5 0" block_rpy="0 0 1.57" material="KitchenWhite"/>
-  
-  <cash_register name="cash" parent="kitchen" xyz="0.5 -4.4 0.73" rpy="0 0 3.1415"/>
+  <xacro:shopping_block name="right_shopping_block" parent="kitchen" block_pos="2.2 -6.97 0" block_rpy="0 0 1.57"/>
   
   
+  <xacro:table name="cash1" parent="kitchen" block_pos="1.52 -5 0" block_rpy="0 0 1.57" material="KitchenWhite"/>
+  <xacro:small_table name="cash2" parent="kitchen" block_pos="0.9 -5 0" block_rpy="0 0 1.57" material="KitchenWhite"/>
   
-  <table name="eating_table" parent="kitchen" block_pos="-1.7 -2.1 0" block_rpy="0 0 1.57" material="KitchenWhite"/>
-  <chair name="eating_1" parent="kitchen" xyz="-1.35 -1.2 0" rpy="0 0 1.57"/>
-  <chair name="eating_2" parent="kitchen" xyz="-1.35 -1.8 0" rpy="0 0 1.57"/>
-  <chair name="eating_3" parent="kitchen" xyz="-2.65 -0.75 0" rpy="0 0 -1.57"/>
-  <chair name="eating_4" parent="kitchen" xyz="-2.65 -1.35 0" rpy="0 0 -1.57"/>
+  <xacro:cash_register name="cash" parent="kitchen" xyz="0.5 -4.4 0.73" rpy="0 0 3.1415"/>
+  
+  
+  
+  <xacro:table name="eating_table" parent="kitchen" block_pos="-1.7 -2.1 0" block_rpy="0 0 1.57" material="KitchenWhite"/>
+  <xacro:chair name="eating_1" parent="kitchen" xyz="-1.35 -1.2 0" rpy="0 0 1.57"/>
+  <xacro:chair name="eating_2" parent="kitchen" xyz="-1.35 -1.8 0" rpy="0 0 1.57"/>
+  <xacro:chair name="eating_3" parent="kitchen" xyz="-2.65 -0.75 0" rpy="0 0 -1.57"/>
+  <xacro:chair name="eating_4" parent="kitchen" xyz="-2.65 -1.35 0" rpy="0 0 -1.57"/>
   
   
   <joint name="tempLink" type="fixed">
@@ -261,39 +187,39 @@
   <!--            -->
   
  
-  <table name="work1" parent="room" block_pos="-4.05 -0.15 0" block_rpy="0 0 0" material="LightBrown2"/>
-  <table name="work2" parent="room" block_pos="-2.44 -0.15 0" block_rpy="0 0 0" material="LightBrown2"/>
-  <table name="work3" parent="room" block_pos="-0.83 -0.15 0" block_rpy="0 0 0" material="LightBrown2"/>
-  <table name="work4" parent="room" block_pos="0.77 -1.71 0" block_rpy="0 0 1.57" material="LightBrown2"/>
+  <xacro:table name="work1" parent="room" block_pos="-4.05 -0.15 0" block_rpy="0 0 0" material="LightBrown2"/>
+  <xacro:table name="work2" parent="room" block_pos="-2.44 -0.15 0" block_rpy="0 0 0" material="LightBrown2"/>
+  <xacro:table name="work3" parent="room" block_pos="-0.83 -0.15 0" block_rpy="0 0 0" material="LightBrown2"/>
+  <xacro:table name="work4" parent="room" block_pos="0.77 -1.71 0" block_rpy="0 0 1.57" material="LightBrown2"/>
 
   
-  <chair name="work1_1" parent="room" xyz="-2.75 0.7 0" rpy="0 0 3.1415"/>
-  <chair name="work1_2" parent="room" xyz="-3.35 0.7 0" rpy="0 0 3.1415"/>
-  <chair name="work2_1" parent="room" xyz="-1.14 0.7 0" rpy="0 0 3.1415"/>
-  <chair name="work2_2" parent="room" xyz="-1.74 0.7 0" rpy="0 0 3.1415"/>
-  <chair name="work3_1" parent="room" xyz="0.47 0.7 0" rpy="0 0 3.1415"/>
-  <chair name="work3_2" parent="room" xyz="-0.13 0.7 0" rpy="0 0 3.1415"/>
-  <chair name="work4_1" parent="room" xyz="0.93 -1.35 0" rpy="0 0 1.57"/>
-  <chair name="work4_2" parent="room" xyz="0.93 -0.7 0" rpy="0 0 1.57"/>
+  <xacro:chair name="work1_1" parent="room" xyz="-2.75 0.7 0" rpy="0 0 3.1415"/>
+  <xacro:chair name="work1_2" parent="room" xyz="-3.35 0.7 0" rpy="0 0 3.1415"/>
+  <xacro:chair name="work2_1" parent="room" xyz="-1.14 0.7 0" rpy="0 0 3.1415"/>
+  <xacro:chair name="work2_2" parent="room" xyz="-1.74 0.7 0" rpy="0 0 3.1415"/>
+  <xacro:chair name="work3_1" parent="room" xyz="0.47 0.7 0" rpy="0 0 3.1415"/>
+  <xacro:chair name="work3_2" parent="room" xyz="-0.13 0.7 0" rpy="0 0 3.1415"/>
+  <xacro:chair name="work4_1" parent="room" xyz="0.93 -1.35 0" rpy="0 0 1.57"/>
+  <xacro:chair name="work4_2" parent="room" xyz="0.93 -0.7 0" rpy="0 0 1.57"/>
   
   <!--             -->
   <!-- cnc bereich -->
   <!--             -->
   
   
-  <shopping_block name="cnc_shopping_block" parent="room" block_pos="1 5 0" block_rpy="0 0 -1.57"/>
-  <cnc name="cnc" parent="room" xyz="2.7 4 0" rpy="0 0 -1.57"/>
+  <xacro:shopping_block name="cnc_shopping_block" parent="room" block_pos="1 5 0" block_rpy="0 0 -1.57"/>
+  <xacro:cnc name="cnc" parent="room" xyz="2.7 4 0" rpy="0 0 -1.57"/>
   
   <!--            -->
   <!-- bio lab    -->
   <!--            -->
   
-  <table name="bio1" parent="room" block_pos="-1.48 4.2 0" block_rpy="0 0 0" material="KitchenWhite"/>
-  <table name="bio2" parent="room" block_pos="-3.1 4.2 0" block_rpy="0 0 0" material="KitchenWhite"/>
-  <table name="bio3" parent="room" block_pos="-4.72 4.2 0" block_rpy="0 0 0" material="KitchenWhite"/>
+  <xacro:table name="bio1" parent="room" block_pos="-1.48 4.2 0" block_rpy="0 0 0" material="KitchenWhite"/>
+  <xacro:table name="bio2" parent="room" block_pos="-3.1 4.2 0" block_rpy="0 0 0" material="KitchenWhite"/>
+  <xacro:table name="bio3" parent="room" block_pos="-4.72 4.2 0" block_rpy="0 0 0" material="KitchenWhite"/>
   
-  <test_glasses name="glasses1" parent="room" xyz="-2.1 4.5 0.73" rpy="0 0 1.57"/>
-  <glasses name="glasses2" parent="room" xyz="-1.1 4.3 0.73" rpy="0 0 0"/>
+  <xacro:test_glasses name="glasses1" parent="room" xyz="-2.1 4.5 0.73" rpy="0 0 1.57"/>
+  <xacro:glasses name="glasses2" parent="room" xyz="-1.1 4.3 0.73" rpy="0 0 0"/>
   
 </robot>
     

--- a/iai_kitchen_defs/room/bio_area.urdf.xml
+++ b/iai_kitchen_defs/room/bio_area.urdf.xml
@@ -8,14 +8,14 @@
 
   
   <link name="bio_area_link">
-    <sphere_inertia radius="0.001" mass="0"/>
+    <xacro:sphere_inertia radius="0.001" mass="0"/>
   </link>
 
-  <table name="bio1" parent="bio_area" block_pos="-1.48 4.2 0" block_rpy="0 0 0" material="KitchenWhite"/>
-  <table name="bio2" parent="bio_area" block_pos="-3.1 4.2 0" block_rpy="0 0 0" material="KitchenWhite"/>
-  <table name="bio3" parent="bio_area" block_pos="-4.72 4.2 0" block_rpy="0 0 0" material="KitchenWhite"/>
+  <xacro:table name="bio1" parent="bio_area" block_pos="-1.48 4.2 0" block_rpy="0 0 0" material="KitchenWhite"/>
+  <xacro:table name="bio2" parent="bio_area" block_pos="-3.1 4.2 0" block_rpy="0 0 0" material="KitchenWhite"/>
+  <xacro:table name="bio3" parent="bio_area" block_pos="-4.72 4.2 0" block_rpy="0 0 0" material="KitchenWhite"/>
   
-  <test_glasses name="glasses1" parent="bio_area" xyz="-2.1 4.5 0.73" rpy="0 0 1.57"/>
-  <glasses name="glasses2" parent="bio_area" xyz="-1.1 4.3 0.73" rpy="0 0 0"/>
+  <xacro:test_glasses name="glasses1" parent="bio_area" xyz="-2.1 4.5 0.73" rpy="0 0 1.57"/>
+  <xacro:glasses name="glasses2" parent="bio_area" xyz="-1.1 4.3 0.73" rpy="0 0 0"/>
 
 </robot>

--- a/iai_kitchen_defs/room/bio_area.urdf.xml
+++ b/iai_kitchen_defs/room/bio_area.urdf.xml
@@ -2,8 +2,8 @@
 <robot name="bio_area" xmlns:xacro="http://www.ros.org/wiki/xacro">
   
   <xacro:include filename="$(find iai_kitchen_defs)/defs/util_defs.xml"/>  
-  <xacro:include filename="$(find iai_kitchen_defs)/Media/models/test_glasses.urdf"/>
-  <xacro:include filename="$(find iai_kitchen_defs)/Media/models/glasses.urdf"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/Media/models/test_glasses.urdf.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/Media/models/glasses.urdf.xml"/>
   <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/table.xml"/>
 
   

--- a/iai_kitchen_defs/room/cnc_area.urdf.xml
+++ b/iai_kitchen_defs/room/cnc_area.urdf.xml
@@ -6,9 +6,9 @@
   <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/furniture_defs.xml"/>
  
   <link name="cnc_area_link">
-    <sphere_inertia radius="0" mass="0"/>
+    <xacro:sphere_inertia radius="0" mass="0"/>
   </link>
 
-  <shopping_block name="cnc_shopping_block" parent="cnc_area" block_pos="0 0 0" block_rpy="0 0 0"/>
+  <xacro:shopping_block name="cnc_shopping_block" parent="cnc_area" block_pos="0 0 0" block_rpy="0 0 0"/>
 
 </robot>

--- a/iai_kitchen_defs/room/colorTest.urdf.xml
+++ b/iai_kitchen_defs/room/colorTest.urdf.xml
@@ -1,50 +1,18 @@
 <?xml version="1.0"?>
 <robot name="room" xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+  <xacro:include filename="$(find iai_kitchen_defs)/defs/util_defs.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/room/lab_macros.xml"/>
+
+  <link name="room_link">
+    <xacro:sphere_inertia radius="0.001" mass="1"/>
+  </link>
 
 
- <wall name="boden_kitchen" xyz="-2.65 -3.7 1.0005" sxyz="5.3 6.8 0.5" material="Ias/LightBrown2"/>
- <wall name="boden_shop" xyz="1.95 -4 1.0005" sxyz="3.9 6 0.5" material="Ias/LightBrown"/>
- <!--wall name="boden_mech" xyz="1.95 2 1.0005" sxyz="3.9 6 0.5" material="Ground/Red"/>
- <wall name="boden_bio" xyz="-2.65 2.35 1.0005" sxyz="5.3 5.3 0.5" material="Ground/Green"/-->
+  <xacro:wall name="boden_kitchen" parent="room" xyz="-2.65 -3.7 1.0005" sxyz="5.3 6.8 0.5" material="Ias/LightBrown2"/>
+  <xacro:wall name="boden_shop" parent="room" xyz="1.95 -4 1.0005" sxyz="3.9 6 0.5" material="Ias/LightBrown"/>
+  <!--xacro:wall name="boden_mech" xyz="1.95 2 1.0005" sxyz="3.9 6 0.5" material="Ground/Red"/>
+  <xacro:wall name="boden_bio" xyz="-2.65 2.35 1.0005" sxyz="5.3 5.3 0.5" material="Ground/Green"/-->
  
-
- <link name="room_link">
-   <sphere_inertia radius="0.001" mass="1"/>
- </link>
- 
-
- <!-- macro for walls -->
- <macro name="wall" params="name xyz sxyz material">
-   
-   <joint name="${name}_joint" type="fixed">
-     <origin rpy="0 0 0" xyz="${xyz}"/>
-     <parent link="room_link"/>
-     <child link="${name}_link"/>
-   </joint>
-   
-   <link name="${name}_link">
-     <visual>
-       <origin xyz="0 0 0" rpy="0 0 0"/>
-       <geometry>
-         <box size="${sxyz}"/>
-       </geometry>
-     </visual>      
-     <collision>
-       <origin xyz="0 0 0" rpy="0 0 0"/>
-       <geometry>
-         <box size="${sxyz}"/>
-       </geometry> 
-     </collision>
-     <inertial>
-       <mass value="1000" />
-       <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0" />
-     </inertial>
-   </link>    
-   <gazebo reference="${name}_link">
-     <static>true</static>
-     <material>${material}</material>
-   </gazebo>
- </macro>
  
 </robot>

--- a/iai_kitchen_defs/room/kitchen_area.urdf.xml
+++ b/iai_kitchen_defs/room/kitchen_area.urdf.xml
@@ -18,19 +18,19 @@
   </link>
   
   <!-- Shelves on top of kitchen counter -->
-  <!--<counter parent="kitchen"
+  <!--<xacro:counter parent="kitchen"
   name="shelf_bottom"
   pos_x="-5.22" pos_y="-5.65" pos_z="0.85"
   roll="0" pitch="0" yaw="0"
   size_x="0.25" size_y="0.38" size_z="0.025"
   />
-  <counter parent="kitchen"
+  <xacro:counter parent="kitchen"
   name="shelf_center"
   pos_x="-5.22" pos_y="-5.65" pos_z="1.15"
   roll="0" pitch="0" yaw="0"
   size_x="0.21" size_y="0.38" size_z="0.025"
   />
-  <counter parent="kitchen"
+  <xacro:counter parent="kitchen"
   name="shelf_top"
   pos_x="-5.22" pos_y="-5.65" pos_z="1.48"
   roll="0" pitch="0" yaw="0"
@@ -38,23 +38,23 @@
   />-->
 
   <!-- Finally, the 5 main blocks of the kitchen -->
-  <island_block block_pos="-2.1 -4.94 0" block_rpy="0 0 3.141"/>
+  <xacro:island_block block_pos="-2.1 -4.94 0" block_rpy="0 0 3.141"/>
   
-  <oven_block block_pos="-5.27 -6.85 0" block_rpy="0 0 0"/>
+  <xacro:oven_block block_pos="-5.27 -6.85 0" block_rpy="0 0 0"/>
   
-  <sink_block block_pos="-5.29 -5.65 0" block_rpy="0 0 0"/>
+  <xacro:sink_block block_pos="-5.29 -5.65 0" block_rpy="0 0 0"/>
   
-  <fridge_block block_pos="-5.29 -3.59 0" block_rpy="0 0 0"/>
+  <xacro:fridge_block block_pos="-5.29 -3.59 0" block_rpy="0 0 0"/>
   
-  <table name="pancake_table" parent="kitchen" block_pos="-2.1 -4.77 0.0" block_rpy="0 0 1.57" material="KitchenWhite" />
+  <xacro:table name="pancake_table" parent="kitchen" block_pos="-2.1 -4.77 0.0" block_rpy="0 0 1.57" material="KitchenWhite" />
   
   
-  <!--<table name="eating_table" parent="kitchen" block_pos="-1.7 -2.1 0" block_rpy="0 0 1.57" material="KitchenWhite"/>-->
+  <!--<xacro:table name="eating_table" parent="kitchen" block_pos="-1.7 -2.1 0" block_rpy="0 0 1.57" material="KitchenWhite"/>-->
     
-<!--    <chair name="eating_1" parent="kitchen" xyz="-1.35 -1.2 0" rpy="0 0 1.57"/>
-    <chair name="eating_2" parent="kitchen" xyz="-1.35 -1.8 0" rpy="0 0 1.57"/>
-    <chair name="eating_3" parent="kitchen" xyz="-2.65 -0.75 0" rpy="0 0 -1.57"/>
-    <chair name="eating_4" parent="kitchen" xyz="-2.65 -1.35 0" rpy="0 0 -1.57"/>-->
+<!--    <xacro:chair name="eating_1" parent="kitchen" xyz="-1.35 -1.2 0" rpy="0 0 1.57"/>
+    <xacro:chair name="eating_2" parent="kitchen" xyz="-1.35 -1.8 0" rpy="0 0 1.57"/>
+    <xacro:chair name="eating_3" parent="kitchen" xyz="-2.65 -0.75 0" rpy="0 0 -1.57"/>
+    <xacro:chair name="eating_4" parent="kitchen" xyz="-2.65 -1.35 0" rpy="0 0 -1.57"/>-->
   
 
 </robot>

--- a/iai_kitchen_defs/room/kitchen_area.urdf.xml
+++ b/iai_kitchen_defs/room/kitchen_area.urdf.xml
@@ -14,7 +14,7 @@
   
   <!-- This is the top level joint /tf frame. -->
   <link name="kitchen_link">
-    <!--<sphere_inertia radius="0.001" mass="1"/>-->
+    <!--<xacro:sphere_inertia radius="0.001" mass="1"/>-->
   </link>
   
   <!-- Shelves on top of kitchen counter -->

--- a/iai_kitchen_defs/room/lab_macros.xml
+++ b/iai_kitchen_defs/room/lab_macros.xml
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <!-- macro for walls -->
-  <macro name="wall" params="name parent xyz sxyz material">
+  <xacro:macro name="wall" params="name parent xyz sxyz material">
     
     <joint name="${name}_joint" type="fixed">
       <origin rpy="0 0 0" xyz="${xyz}"/>
@@ -32,11 +32,11 @@
       <static>true</static>
       <material>${material}</material>
     </gazebo>
-  </macro>
+  </xacro:macro>
   
   
   <!-- macro for pillars -->
-  <macro name="pillar" params="name parent xyz radius length">
+  <xacro:macro name="pillar" params="name parent xyz radius length">
     
     <joint name="${name}_joint" type="fixed">
       <origin rpy="0 0 0" xyz="${xyz}"/>
@@ -65,6 +65,6 @@
     <gazebo reference="${name}_link">
       <static>true</static>
     </gazebo>
-  </macro>
+  </xacro:macro>
   
 </robot>

--- a/iai_kitchen_defs/room/room.urdf.xml
+++ b/iai_kitchen_defs/room/room.urdf.xml
@@ -15,82 +15,82 @@
   
   <!-- west wall -->
   
-  <wall name="w_wall_right" parent="room" xyz="2.785 4.99 1.25" sxyz="0.54 0.1 2.5" material="Gazebo/White"/>
-  <wall name="w_wall_right_window" parent="room" xyz="1.415 4.99 0.2925" sxyz="2.2 0.1 0.585" material="Gazebo/White"/>
-  <wall name="w_window_right" parent="room" xyz="1.415 4.99 1.5425" sxyz="2.2 0.1 1.915" material="Gazebo/BlueTransparent"/>
-  <wall name="w_wall_center" parent="room" xyz="0.025 4.99 1.25" sxyz="0.58 0.1 2.5" material="Gazebo/White"/>
-  <wall name="w_wall_center_window" parent="room" xyz="-1.365 4.99 0.2925" sxyz="2.2 0.1 0.585" material="Gazebo/White"/>
-  <wall name="w_window_center" parent="room" xyz="-1.365 4.99 1.5425" sxyz="2.2 0.1 1.915" material="Gazebo/BlueTransparent"/>
-  <wall name="w_wall_left" parent="room" xyz="-3.07025 4.99 1.25" sxyz="1.215 0.1 2.5" material="Custom/acat"/>
-  <wall name="w_wall_left_window" parent="room" xyz="-4.263 4.99 0.075" sxyz="1.175 0.1 0.15" material="Gazebo/White"/>
-  <wall name="w_window_left" parent="room" xyz="-4.263 4.99 1.325" sxyz="1.175 0.1 2.35" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="w_wall_right" parent="room" xyz="2.785 4.99 1.25" sxyz="0.54 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="w_wall_right_window" parent="room" xyz="1.415 4.99 0.2925" sxyz="2.2 0.1 0.585" material="Gazebo/White"/>
+  <xacro:wall name="w_window_right" parent="room" xyz="1.415 4.99 1.5425" sxyz="2.2 0.1 1.915" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="w_wall_center" parent="room" xyz="0.025 4.99 1.25" sxyz="0.58 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="w_wall_center_window" parent="room" xyz="-1.365 4.99 0.2925" sxyz="2.2 0.1 0.585" material="Gazebo/White"/>
+  <xacro:wall name="w_window_center" parent="room" xyz="-1.365 4.99 1.5425" sxyz="2.2 0.1 1.915" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="w_wall_left" parent="room" xyz="-3.07025 4.99 1.25" sxyz="1.215 0.1 2.5" material="Custom/acat"/>
+  <xacro:wall name="w_wall_left_window" parent="room" xyz="-4.263 4.99 0.075" sxyz="1.175 0.1 0.15" material="Gazebo/White"/>
+  <xacro:wall name="w_window_left" parent="room" xyz="-4.263 4.99 1.325" sxyz="1.175 0.1 2.35" material="Gazebo/BlueTransparent"/>
   
   
   <!-- east wall -->
   
-  <wall name="e_wall_right" parent="room" xyz="-5.2605 -7.08 1.25" sxyz="0.21 0.1 2.5" material="Gazebo/White"/>
-  <wall name="e_wall_right_window" parent="room" xyz="-4.0705 -7.08 0.2925" sxyz="2.17 0.1 0.585" material="Gazebo/White"/>
-  <wall name="e_window_right" parent="room" xyz="-4.0705 -7.08 1.5425" sxyz="2.17 0.1 1.915" material="Gazebo/BlueTransparent"/>
-  <wall name="e_wall_center_right" parent="room" xyz="-2.6955 -7.08 1.25" sxyz="0.58 0.1 2.5" material="Custom/robohow"/>
-  <wall name="e_wall_center_window" parent="room" xyz="-1.3205 -7.08 0.2925" sxyz="2.17 0.1 0.585" material="Gazebo/White"/>
-  <wall name="e_window_center" parent="room" xyz="-1.3205 -7.08 1.5425" sxyz="2.17 0.1 1.915" material="Gazebo/BlueTransparent"/>
-  <wall name="e_wall_center_left" parent="room" xyz="0.0545 -7.08 1.25" sxyz="0.58 0.1 2.5" material="Custom/roboearth2"/>
-  <wall name="e_wall_left_window" parent="room" xyz="1.4395 -7.08 0.2925" sxyz="2.19 0.1 0.585" material="Gazebo/White"/>
-  <wall name="e_window_left" parent="room" xyz="1.4395 -7.08 1.5425" sxyz="2.19 0.1 1.915" material="Gazebo/BlueTransparent"/>  
-  <wall name="e_wall_left" parent="room" xyz="2.8 -7.08 1.25" sxyz="0.531 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="e_wall_right" parent="room" xyz="-5.2605 -7.08 1.25" sxyz="0.21 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="e_wall_right_window" parent="room" xyz="-4.0705 -7.08 0.2925" sxyz="2.17 0.1 0.585" material="Gazebo/White"/>
+  <xacro:wall name="e_window_right" parent="room" xyz="-4.0705 -7.08 1.5425" sxyz="2.17 0.1 1.915" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="e_wall_center_right" parent="room" xyz="-2.6955 -7.08 1.25" sxyz="0.58 0.1 2.5" material="Custom/robohow"/>
+  <xacro:wall name="e_wall_center_window" parent="room" xyz="-1.3205 -7.08 0.2925" sxyz="2.17 0.1 0.585" material="Gazebo/White"/>
+  <xacro:wall name="e_window_center" parent="room" xyz="-1.3205 -7.08 1.5425" sxyz="2.17 0.1 1.915" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="e_wall_center_left" parent="room" xyz="0.0545 -7.08 1.25" sxyz="0.58 0.1 2.5" material="Custom/roboearth2"/>
+  <xacro:wall name="e_wall_left_window" parent="room" xyz="1.4395 -7.08 0.2925" sxyz="2.19 0.1 0.585" material="Gazebo/White"/>
+  <xacro:wall name="e_window_left" parent="room" xyz="1.4395 -7.08 1.5425" sxyz="2.19 0.1 1.915" material="Gazebo/BlueTransparent"/>  
+  <xacro:wall name="e_wall_left" parent="room" xyz="2.8 -7.08 1.25" sxyz="0.531 0.1 2.5" material="Gazebo/White"/>
   
   
   <!-- north wall (left room) -->
   
-  <wall name="n_l_wall_right" parent="room" xyz="3.90 -0.055 1.25" sxyz="0.1 0.94 2.5" material="Custom/logos"/>
-  <wall name="n_l_wall_center_window" parent="room" xyz="3.90 1.705 0.075" sxyz="0.1 2.58 0.15" material="Gazebo/White"/>
-  <wall name="n_l_window_center" parent="room" xyz="3.90 1.705 1.325" sxyz="0.1 2.58 2.35" material="Gazebo/BlueTransparent"/>
-  <wall name="n_l_wall_left" parent="room" xyz="3.90 3.57 1.25" sxyz="0.1 1.15 2.5" material="Custom/saphari"/>
+  <xacro:wall name="n_l_wall_right" parent="room" xyz="3.90 -0.055 1.25" sxyz="0.1 0.94 2.5" material="Custom/logos"/>
+  <xacro:wall name="n_l_wall_center_window" parent="room" xyz="3.90 1.705 0.075" sxyz="0.1 2.58 0.15" material="Gazebo/White"/>
+  <xacro:wall name="n_l_window_center" parent="room" xyz="3.90 1.705 1.325" sxyz="0.1 2.58 2.35" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="n_l_wall_left" parent="room" xyz="3.90 3.57 1.25" sxyz="0.1 1.15 2.5" material="Custom/saphari"/>
   
   
   <!-- north wall (right room) -->
   
-  <wall name="n_r_wall_right" parent="room" xyz="3.90 -3.985 1.25" sxyz="0.1 4.5 2.5" material="Custom/unihb_tum"/>
-  <wall name="n_r_wall_center_window" parent="room" xyz="3.90 -1.13 0.075" sxyz="0.1 1.21 0.15" material="Gazebo/White"/>
-  <wall name="n_r_window_center" parent="room" xyz="3.90 -1.13 1.325" sxyz="0.1 1.21 2.35" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="n_r_wall_right" parent="room" xyz="3.90 -3.985 1.25" sxyz="0.1 4.5 2.5" material="Custom/unihb_tum"/>
+  <xacro:wall name="n_r_wall_center_window" parent="room" xyz="3.90 -1.13 0.075" sxyz="0.1 1.21 0.15" material="Gazebo/White"/>
+  <xacro:wall name="n_r_window_center" parent="room" xyz="3.90 -1.13 1.325" sxyz="0.1 1.21 2.35" material="Gazebo/BlueTransparent"/>
 
   
   <!-- south wall (left room) -->
   
-  <wall name="s_l_wall_right" parent="room" xyz="-4.9005 4.13 1.25" sxyz="0.1 1.82 2.5" material="Gazebo/White"/>
-  <wall name="s_l_wall_v_right" parent="room" xyz="-5.1655 3.27 1.25" sxyz="0.43 0.1 2.5" material="Gazebo/White"/>
-  <wall name="s_l_wall_door_right" parent="room" xyz="-5.3305 3.08 1.25" sxyz="0.1 0.28 2.5" material="Gazebo/White"/>
-  <wall name="s_l_wall_door_left" parent="room" xyz="-5.3305 1.74 1.25" sxyz="0.1 0.28 2.5" material="Gazebo/White"/>
-  <wall name="s_l_wall_v_left" parent="room" xyz="-4.8655 1.55 1.25" sxyz="1.0 0.1 2.5" material="Gazebo/White"/>  
-  <wall name="s_l_wall_left" parent="room" xyz="-4.3155 0.545 1.25" sxyz="0.1 2.11 2.5" material="Gazebo/White"/>
+  <xacro:wall name="s_l_wall_right" parent="room" xyz="-4.9005 4.13 1.25" sxyz="0.1 1.82 2.5" material="Gazebo/White"/>
+  <xacro:wall name="s_l_wall_v_right" parent="room" xyz="-5.1655 3.27 1.25" sxyz="0.43 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="s_l_wall_door_right" parent="room" xyz="-5.3305 3.08 1.25" sxyz="0.1 0.28 2.5" material="Gazebo/White"/>
+  <xacro:wall name="s_l_wall_door_left" parent="room" xyz="-5.3305 1.74 1.25" sxyz="0.1 0.28 2.5" material="Gazebo/White"/>
+  <xacro:wall name="s_l_wall_v_left" parent="room" xyz="-4.8655 1.55 1.25" sxyz="1.0 0.1 2.5" material="Gazebo/White"/>  
+  <xacro:wall name="s_l_wall_left" parent="room" xyz="-4.3155 0.545 1.25" sxyz="0.1 2.11 2.5" material="Gazebo/White"/>
   
 
   <!-- south wall (right room) -->
   
-  <wall name="wall_door_left" parent="room" xyz="-4.3155 -1.9 1.25" sxyz="0.1 0.42 2.5" material="Gazebo/White"/>
-  <wall name="wall_v" parent="room" xyz="-4.8655 -2.06 1.25" sxyz="1.0 0.1 2.5" material="Gazebo/White"/>
-  <wall name="wall_left" parent="room" xyz="-5.3155 -4.57 1.25" sxyz="0.1 4.92 2.5" material="Gazebo/White"/>
+  <xacro:wall name="wall_door_left" parent="room" xyz="-4.3155 -1.9 1.25" sxyz="0.1 0.42 2.5" material="Gazebo/White"/>
+  <xacro:wall name="wall_v" parent="room" xyz="-4.8655 -2.06 1.25" sxyz="1.0 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="wall_left" parent="room" xyz="-5.3155 -4.57 1.25" sxyz="0.1 4.92 2.5" material="Gazebo/White"/>
   
   
   <!-- pillars -->
   
-  <pillar name="small_pillar" parent="room" xyz="0 -0.3 1.25" radius="0.15" length="2.5" />
-  <pillar name="large_pillar_1" parent="room" xyz="3.85 -7.03 1.25" radius="0.795" length="2.5" />
-  <pillar name="large_pillar_2" parent="room" xyz="3.85 4.94 1.25" radius="0.795" length="2.5" />
+  <xacro:pillar name="small_pillar" parent="room" xyz="0 -0.3 1.25" radius="0.15" length="2.5" />
+  <xacro:pillar name="large_pillar_1" parent="room" xyz="3.85 -7.03 1.25" radius="0.795" length="2.5" />
+  <xacro:pillar name="large_pillar_2" parent="room" xyz="3.85 4.94 1.25" radius="0.795" length="2.5" />
   
   
   <!-- partition walls -->
   
-  <wall name="partition_wall_work1" parent="room" xyz="-1.06 -2.04 0.37" sxyz="4.81 0.01 0.74" material="Gazebo/White"/>
-  <!--<wall name="partition_wall_work2" parent="room" xyz="0 -1 0.5" sxyz="0.1 1.5 1" material="Gazebo/White"/>-->
-  <wall name="partition_wall_shop" parent="room" xyz="1.35 -5.05 0.37" sxyz="0.01 4.05 0.74" material="Gazebo/White"/>
+  <xacro:wall name="partition_wall_work1" parent="room" xyz="-1.06 -2.04 0.37" sxyz="4.81 0.01 0.74" material="Gazebo/White"/>
+  <!--<xacro:wall name="partition_wall_work2" parent="room" xyz="0 -1 0.5" sxyz="0.1 1.5 1" material="Gazebo/White"/>-->
+  <xacro:wall name="partition_wall_shop" parent="room" xyz="1.35 -5.05 0.37" sxyz="0.01 4.05 0.74" material="Gazebo/White"/>
  
   
   <!-- ground -->
   
-<!--  <wall name="ground_kitchen" parent="room" xyz="-2.65 -3.7 0.005" sxyz="5.3 6.8 00.01" material="Ground/Blue"/>
-  <wall name="ground_shop" parent="room" xyz="1.95 -4 0.005" sxyz="3.9 6 00.01" material="Ground/Yellow"/>
-  <wall name="ground_mech" parent="room" xyz="1.95 2 0.005" sxyz="3.9 6 00.01" material="Ground/Red"/>
-  <wall name="ground_bio" parent="room" xyz="-2.65 2.35 0.005" sxyz="5.3 5.3 00.01" material="Ground/Green"/>  -->
+<!--  <xacro:wall name="ground_kitchen" parent="room" xyz="-2.65 -3.7 0.005" sxyz="5.3 6.8 00.01" material="Ground/Blue"/>
+  <xacro:wall name="ground_shop" parent="room" xyz="1.95 -4 0.005" sxyz="3.9 6 00.01" material="Ground/Yellow"/>
+  <xacro:wall name="ground_mech" parent="room" xyz="1.95 2 0.005" sxyz="3.9 6 00.01" material="Ground/Red"/>
+  <xacro:wall name="ground_bio" parent="room" xyz="-2.65 2.35 0.005" sxyz="5.3 5.3 00.01" material="Ground/Green"/>  -->
   
 </robot>

--- a/iai_kitchen_defs/room/room.urdf.xml
+++ b/iai_kitchen_defs/room/room.urdf.xml
@@ -10,7 +10,7 @@
 
   
   <link name="room_link">
-    <!--<sphere_inertia radius="0.001" mass="1"/>-->
+    <!--<xacro:sphere_inertia radius="0.001" mass="1"/>-->
   </link>
   
   <!-- west wall -->

--- a/iai_kitchen_defs/room/shopping_area.urdf.xml
+++ b/iai_kitchen_defs/room/shopping_area.urdf.xml
@@ -10,18 +10,18 @@
   
   
   <link name="shopping_area_link">
-    <sphere_inertia radius="0.001" mass="1"/>
+    <xacro:sphere_inertia radius="0.001" mass="1"/>
   </link>
   
-  <shopping_block name="left_shopping_block" parent="shopping_area" block_pos="3.8 -4.1 0" block_rpy="0 0 3.141"/>
+  <xacro:shopping_block name="left_shopping_block" parent="shopping_area" block_pos="3.8 -4.1 0" block_rpy="0 0 3.141"/>
 <!--  
   <wine_cooler name="cooler" parent="shopping_area" xyz="3.0 -5.5 0" rpy="0 0 3.9265"/>    
   -->
-  <shopping_block name="right_shopping_block" parent="shopping_area" block_pos="2.2 -6.97 0" block_rpy="0 0 1.57"/>   
+  <xacro:shopping_block name="right_shopping_block" parent="shopping_area" block_pos="2.2 -6.97 0" block_rpy="0 0 1.57"/>   
   
-  <table name="cash_table_1" parent="shopping_area" block_pos="1.52 -5 0" block_rpy="0 0 1.57" material="KitchenWhite"/>
+  <xacro:table name="cash_table_1" parent="shopping_area" block_pos="1.52 -5 0" block_rpy="0 0 1.57" material="KitchenWhite"/>
   
-  <small_table name="cash_table_2" parent="shopping_area" block_pos="0.9 -5 0" block_rpy="0 0 1.57" material="KitchenWhite"/>    
+  <xacro:small_table name="cash_table_2" parent="shopping_area" block_pos="0.9 -5 0" block_rpy="0 0 1.57" material="KitchenWhite"/>    
 <!--  
   <cash_register name="cash" parent="shopping_area" xyz="0.5 -4.4 0.73" rpy="0 0 3.1415"/>
   -->

--- a/iai_kitchen_defs/room/test.urdf.xml
+++ b/iai_kitchen_defs/room/test.urdf.xml
@@ -2,6 +2,7 @@
 <robot name="room" xmlns:xacro="http://www.ros.org/wiki/xacro">
   
   <xacro:include filename="$(find iai_kitchen_defs)/defs/util_defs.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/room/lab_macros.xml"/>
   <xacro:include filename="$(find iai_kitchen_defs)/Media/models/cash_register.urdf.xml"/>
   <xacro:include filename="$(find iai_kitchen_defs)/Media/models/chair.urdf.xml"/>
   <xacro:include filename="$(find iai_kitchen_defs)/Media/models/cnc.urdf.xml"/>
@@ -9,192 +10,113 @@
   <xacro:include filename="$(find iai_kitchen_defs)/Media/models/glasses.urdf.xml"/>
   <xacro:include filename="$(find iai_kitchen_defs)/Media/models/wine_cooler.urdf.xml"/>
   
-  
+  <link name="room_link">
+    <xacro:sphere_inertia radius="0.001" mass="1"/>
+  </link>
+
   <!-- west wall -->
   
-  <wall name="w_wall_right" xyz="2.785 4.99 1.25" sxyz="0.54 0.1 2.5" material="Gazebo/White"/>
-  <wall name="w_wall_right_window" xyz="1.415 4.99 0.2925" sxyz="2.2 0.1 0.585" material="Gazebo/White"/>
-  <wall name="w_window_right" xyz="1.415 4.99 1.5425" sxyz="2.2 0.1 1.915" material="Gazebo/BlueTransparent"/>
-  <wall name="w_wall_center" xyz="0.025 4.99 1.25" sxyz="0.58 0.1 2.5" material="Gazebo/White"/>
-  <wall name="w_wall_center_window" xyz="-1.365 4.99 0.2925" sxyz="2.2 0.1 0.585" material="Gazebo/White"/>
-  <wall name="w_window_center" xyz="-1.365 4.99 1.5425" sxyz="2.2 0.1 1.915" material="Gazebo/BlueTransparent"/>
-  <wall name="w_wall_left" xyz="-3.07025 4.99 1.25" sxyz="1.215 0.1 2.5" material="Custom/acat"/>
-  <wall name="w_wall_left_window" xyz="-4.263 4.99 0.075" sxyz="1.175 0.1 0.15" material="Gazebo/White"/>
-  <wall name="w_window_left" xyz="-4.263 4.99 1.325" sxyz="1.175 0.1 2.35" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="w_wall_right" parent="room" xyz="2.785 4.99 1.25" sxyz="0.54 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="w_wall_right_window" parent="room" xyz="1.415 4.99 0.2925" sxyz="2.2 0.1 0.585" material="Gazebo/White"/>
+  <xacro:wall name="w_window_right" parent="room" xyz="1.415 4.99 1.5425" sxyz="2.2 0.1 1.915" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="w_wall_center" parent="room" xyz="0.025 4.99 1.25" sxyz="0.58 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="w_wall_center_window" parent="room" xyz="-1.365 4.99 0.2925" sxyz="2.2 0.1 0.585" material="Gazebo/White"/>
+  <xacro:wall name="w_window_center" parent="room" xyz="-1.365 4.99 1.5425" sxyz="2.2 0.1 1.915" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="w_wall_left" parent="room" xyz="-3.07025 4.99 1.25" sxyz="1.215 0.1 2.5" material="Custom/acat"/>
+  <xacro:wall name="w_wall_left_window" parent="room" xyz="-4.263 4.99 0.075" sxyz="1.175 0.1 0.15" material="Gazebo/White"/>
+  <xacro:wall name="w_window_left" parent="room" xyz="-4.263 4.99 1.325" sxyz="1.175 0.1 2.35" material="Gazebo/BlueTransparent"/>
   
   
   <!-- east wall -->
   
-  <wall name="e_wall_right" xyz="-5.2605 -7.08 1.25" sxyz="0.21 0.1 2.5" material="Gazebo/White"/>
-  <wall name="e_wall_right_window" xyz="-4.0705 -7.08 0.2925" sxyz="2.17 0.1 0.585" material="Gazebo/White"/>
-  <wall name="e_window_right" xyz="-4.0705 -7.08 1.5425" sxyz="2.17 0.1 1.915" material="Gazebo/BlueTransparent"/>
-  <wall name="e_wall_center_right" xyz="-2.6955 -7.08 1.25" sxyz="0.58 0.1 2.5" material="Custom/robohow"/>
-  <wall name="e_wall_center_window" xyz="-1.3205 -7.08 0.2925" sxyz="2.17 0.1 0.585" material="Gazebo/White"/>
-  <wall name="e_window_center" xyz="-1.3205 -7.08 1.5425" sxyz="2.17 0.1 1.915" material="Gazebo/BlueTransparent"/>
-  <wall name="e_wall_center_left" xyz="0.0545 -7.08 1.25" sxyz="0.58 0.1 2.5" material="Custom/roboearth2"/>
-  <wall name="e_wall_left_window" xyz="1.4395 -7.08 0.2925" sxyz="2.19 0.1 0.585" material="Gazebo/White"/>
-  <wall name="e_window_left" xyz="1.4395 -7.08 1.5425" sxyz="2.19 0.1 1.915" material="Gazebo/BlueTransparent"/>  
-  <wall name="e_wall_left" xyz="2.8 -7.08 1.25" sxyz="0.531 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="e_wall_right" parent="room" xyz="-5.2605 -7.08 1.25" sxyz="0.21 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="e_wall_right_window" parent="room" xyz="-4.0705 -7.08 0.2925" sxyz="2.17 0.1 0.585" material="Gazebo/White"/>
+  <xacro:wall name="e_window_right" parent="room" xyz="-4.0705 -7.08 1.5425" sxyz="2.17 0.1 1.915" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="e_wall_center_right" parent="room" xyz="-2.6955 -7.08 1.25" sxyz="0.58 0.1 2.5" material="Custom/robohow"/>
+  <xacro:wall name="e_wall_center_window" parent="room" xyz="-1.3205 -7.08 0.2925" sxyz="2.17 0.1 0.585" material="Gazebo/White"/>
+  <xacro:wall name="e_window_center" parent="room" xyz="-1.3205 -7.08 1.5425" sxyz="2.17 0.1 1.915" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="e_wall_center_left" parent="room" xyz="0.0545 -7.08 1.25" sxyz="0.58 0.1 2.5" material="Custom/roboearth2"/>
+  <xacro:wall name="e_wall_left_window" parent="room" xyz="1.4395 -7.08 0.2925" sxyz="2.19 0.1 0.585" material="Gazebo/White"/>
+  <xacro:wall name="e_window_left" parent="room" xyz="1.4395 -7.08 1.5425" sxyz="2.19 0.1 1.915" material="Gazebo/BlueTransparent"/>  
+  <xacro:wall name="e_wall_left" parent="room" xyz="2.8 -7.08 1.25" sxyz="0.531 0.1 2.5" material="Gazebo/White"/>
   
   
   <!-- north wall (left room) -->
   
-  <wall name="n_l_wall_right" xyz="3.90 -0.055 1.25" sxyz="0.1 0.94 2.5" material="Custom/logos"/>
-  <wall name="n_l_wall_center_window" xyz="3.90 1.705 0.075" sxyz="0.1 2.58 0.15" material="Gazebo/White"/>
-  <wall name="n_l_window_center" xyz="3.90 1.705 1.325" sxyz="0.1 2.58 2.35" material="Gazebo/BlueTransparent"/>
-  <wall name="n_l_wall_left" xyz="3.90 3.57 1.25" sxyz="0.1 1.15 2.5" material="Custom/saphari"/>
+  <xacro:wall name="n_l_wall_right" parent="room" xyz="3.90 -0.055 1.25" sxyz="0.1 0.94 2.5" material="Custom/logos"/>
+  <xacro:wall name="n_l_wall_center_window" parent="room" xyz="3.90 1.705 0.075" sxyz="0.1 2.58 0.15" material="Gazebo/White"/>
+  <xacro:wall name="n_l_window_center" parent="room" xyz="3.90 1.705 1.325" sxyz="0.1 2.58 2.35" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="n_l_wall_left" parent="room" xyz="3.90 3.57 1.25" sxyz="0.1 1.15 2.5" material="Custom/saphari"/>
   
   
   
   <!-- north wall (right room) -->
   
-  <wall name="n_r_wall_right" xyz="3.90 -3.985 1.25" sxyz="0.1 4.5 2.5" material="Custom/unihb_tum"/>
-  <wall name="n_r_wall_center_window" xyz="3.90 -1.13 0.075" sxyz="0.1 1.21 0.15" material="Gazebo/White"/>
-  <wall name="n_r_window_center" xyz="3.90 -1.13 1.325" sxyz="0.1 1.21 2.35" material="Gazebo/BlueTransparent"/>
+  <xacro:wall name="n_r_wall_right" parent="room" xyz="3.90 -3.985 1.25" sxyz="0.1 4.5 2.5" material="Custom/unihb_tum"/>
+  <xacro:wall name="n_r_wall_center_window" parent="room" xyz="3.90 -1.13 0.075" sxyz="0.1 1.21 0.15" material="Gazebo/White"/>
+  <xacro:wall name="n_r_window_center" parent="room" xyz="3.90 -1.13 1.325" sxyz="0.1 1.21 2.35" material="Gazebo/BlueTransparent"/>
 
   
   
   <!-- south wall (left room) -->
   
-  <wall name="s_l_wall_right" xyz="-4.9005 4.13 1.25" sxyz="0.1 1.82 2.5" material="Gazebo/White"/>
-  <wall name="s_l_wall_v_right" xyz="-5.1655 3.27 1.25" sxyz="0.43 0.1 2.5" material="Gazebo/White"/>
-  <wall name="s_l_wall_door_right" xyz="-5.3305 3.08 1.25" sxyz="0.1 0.28 2.5" material="Gazebo/White"/>
-  <wall name="s_l_wall_door_left" xyz="-5.3305 1.74 1.25" sxyz="0.1 0.28 2.5" material="Gazebo/White"/>
-  <wall name="s_l_wall_v_left" xyz="-4.8655 1.55 1.25" sxyz="1.0 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="s_l_wall_right" parent="room" xyz="-4.9005 4.13 1.25" sxyz="0.1 1.82 2.5" material="Gazebo/White"/>
+  <xacro:wall name="s_l_wall_v_right" parent="room" xyz="-5.1655 3.27 1.25" sxyz="0.43 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="s_l_wall_door_right" parent="room" xyz="-5.3305 3.08 1.25" sxyz="0.1 0.28 2.5" material="Gazebo/White"/>
+  <xacro:wall name="s_l_wall_door_left" parent="room" xyz="-5.3305 1.74 1.25" sxyz="0.1 0.28 2.5" material="Gazebo/White"/>
+  <xacro:wall name="s_l_wall_v_left" parent="room" xyz="-4.8655 1.55 1.25" sxyz="1.0 0.1 2.5" material="Gazebo/White"/>
   
-  <wall name="s_l_wall_left" xyz="-4.3155 0.545 1.25" sxyz="0.1 2.11 2.5" material="Gazebo/White"/>
+  <xacro:wall name="s_l_wall_left" parent="room" xyz="-4.3155 0.545 1.25" sxyz="0.1 2.11 2.5" material="Gazebo/White"/>
 
   <!-- south wall (right room) -->
-  <wall name="wall_door_left" xyz="-4.3155 -1.9 1.25" sxyz="0.1 0.42 2.5" material="Gazebo/White"/>
-  <wall name="wall_v" xyz="-4.8655 -2.06 1.25" sxyz="1.0 0.1 2.5" material="Gazebo/White"/>
-  <wall name="wall_left" xyz="-5.3155 -4.57 1.25" sxyz="0.1 4.92 2.5" material="Gazebo/White"/>
+  <xacro:wall name="wall_door_left" parent="room" xyz="-4.3155 -1.9 1.25" sxyz="0.1 0.42 2.5" material="Gazebo/White"/>
+  <xacro:wall name="wall_v" parent="room" xyz="-4.8655 -2.06 1.25" sxyz="1.0 0.1 2.5" material="Gazebo/White"/>
+  <xacro:wall name="wall_left" parent="room" xyz="-5.3155 -4.57 1.25" sxyz="0.1 4.92 2.5" material="Gazebo/White"/>
   
   
   <!-- pillars -->
   
-  <pillar name="small_pillar" xyz="0 -0.3 1.25" r="0.15" />
-  <pillar name="large_pillar_1" xyz="3.85 -7.03 1.25" r="0.795" />
-  <pillar name="large_pillar_2" xyz="3.85 4.94 1.25" r="0.795" />
+  <xacro:pillar name="small_pillar" parent="room" xyz="0 -0.3 1.25" radius="0.15" length="2.5" />
+  <xacro:pillar name="large_pillar_1" parent="room" xyz="3.85 -7.03 1.25" radius="0.795" length="2.5" />
+  <xacro:pillar name="large_pillar_2" parent="room" xyz="3.85 4.94 1.25" radius="0.795" length="2.5" />
   
   
   <!-- partition walls -->
   
-  <wall name="partition_wall_work1" xyz="-2.1 -0.3 0.5" sxyz="4.4 0.1 1" material="Gazebo/White"/>
-  <wall name="partition_wall_work2" xyz="0 -1 0.5" sxyz="0.1 1.5 1" material="Gazebo/White"/>
+  <xacro:wall name="partition_wall_work1" parent="room" xyz="-2.1 -0.3 0.5" sxyz="4.4 0.1 1" material="Gazebo/White"/>
+  <xacro:wall name="partition_wall_work2" parent="room" xyz="0 -1 0.5" sxyz="0.1 1.5 1" material="Gazebo/White"/>
   
-  <wall name="partition_wall_shop" xyz="-0.25 -5 0.5" sxyz="0.1 4 1" material="Gazebo/White"/>
+  <xacro:wall name="partition_wall_shop" parent="room" xyz="-0.25 -5 0.5" sxyz="0.1 4 1" material="Gazebo/White"/>
  
   
   <!-- ground -->
   
-  <wall name="boden_kitchen" xyz="-2.65 -3.7 0.0005" sxyz="5.3 6.8 00.001" material="Ground/Blue"/>
-  <wall name="boden_shop" xyz="1.95 -4 0.0005" sxyz="3.9 6 00.001" material="Ground/Yellow"/>
-  <wall name="boden_mech" xyz="1.95 2 0.0005" sxyz="3.9 6 00.001" material="Ground/Red"/>
-  <wall name="boden_bio" xyz="-2.65 2.35 0.0005" sxyz="5.3 5.3 00.001" material="Ground/Green"/>
+  <xacro:wall name="boden_kitchen" parent="room" xyz="-2.65 -3.7 0.0005" sxyz="5.3 6.8 00.001" material="Ground/Blue"/>
+  <xacro:wall name="boden_shop" parent="room" xyz="1.95 -4 0.0005" sxyz="3.9 6 00.001" material="Ground/Yellow"/>
+  <xacro:wall name="boden_mech" parent="room" xyz="1.95 2 0.0005" sxyz="3.9 6 00.001" material="Ground/Red"/>
+  <xacro:wall name="boden_bio" parent="room" xyz="-2.65 2.35 0.0005" sxyz="5.3 5.3 00.001" material="Ground/Green"/>
   
-  
-  
-  <link name="room_link">
-    <sphere_inertia radius="0.001" mass="1"/>
-  </link>
-  
-  <!-- macro for walls -->
-  <macro name="wall" params="name xyz sxyz material">
-    
-    <joint name="${name}_joint" type="fixed">
-      <origin rpy="0 0 0" xyz="${xyz}"/>
-      <parent link="room_link"/>
-      <child link="${name}_link"/>
-    </joint>
-    
-    <link name="${name}_link">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <box size="${sxyz}"/>
-        </geometry>
-      </visual>      
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <geometry>
-          <box size="${sxyz}"/>
-        </geometry> 
-      </collision>
-      <inertial>
-        <mass value="1000" />
-        <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0" />
-      </inertial>
-    </link>    
-    <gazebo reference="${name}_link">
-      <static>true</static>
-      <material>${material}</material>
-    </gazebo>
-  </macro>
-  
-  
-  <!-- macro for pillars -->
-  <macro name="pillar" params="name xyz r">
-    
-    <joint name="${name}_joint" type="fixed">
-      <origin rpy="0 0 0" xyz="${xyz}"/>
-      <parent link="room_link"/>
-      <child link="${name}_link"/>
-    </joint>
-    
-    <link name="${name}_link">  
-      <visual>
-        <geometry>
-          <cylinder length="2.5" radius="${r}"/>
-        </geometry>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
-      </visual>
-      <collision>
-        <geometry>
-          <cylinder length="2.5" radius="${r}"/>
-        </geometry>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
-      </collision>
-      <inertial>
-        <mass value="1000" />
-        <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0" />
-      </inertial>
-    </link>
-    <gazebo reference="${name}_link">
-      <static>true</static>
-    </gazebo>
-  </macro>
   
   <gazebo>
     <static>true</static>
   </gazebo>
       
       
-      
-      
-      
-  
-  
-  
   <!--         -->
   <!-- Kitchen -->
   <!--         -->
   
   
-  <include filename="$(find iai_maps)/defs/ias_kitchen/furniture_defs.xml"/>
-  <include filename="$(find iai_maps)/defs/ias_kitchen/island_block.xml"/>
-  <include filename="$(find iai_maps)/defs/ias_kitchen/oven_block.xml"/>
-  <include filename="$(find iai_maps)/defs/ias_kitchen/fridge_block.xml"/>
-  <include filename="$(find iai_maps)/defs/ias_kitchen/sink_block.xml"/>
-  <include filename="$(find iai_maps)/defs/ias_kitchen/shopping_block.xml"/>
-  <include filename="$(find iai_maps)/defs/ias_kitchen/table.xml"/>
-  <include filename="$(find iai_maps)/defs/ias_kitchen/small_table.xml"/>
-  <include filename="$(find iai_maps)/defs/ias_kitchen/cuboid.xml"/>
-  
-  
+  <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/furniture_defs.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/island_block.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/oven_block.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/fridge_block.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/sink_block.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/shopping_block.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/table.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/small_table.xml"/>
+  <xacro:include filename="$(find iai_kitchen_defs)/defs/ias_kitchen/cuboid.xml"/>
 
-              
-  
-  
   <!--            -->
   <!-- Worktables -->
   <!--            -->
@@ -212,7 +134,8 @@
   <table name="bio3" parent="room" block_pos="-4.72 4.2 0" block_rpy="0 0 0" material="KitchenWhite"/>-->
   
 <!--  <test_glasses name="glasses1" parent="room" xyz="-2.1 4.5 0.73" rpy="0 0 1.57"/>-->
-  <glasses name="glasses2" parent="room" xyz="-1.1 4.3 0.73" rpy="0 0 0"/>
+
+  <xacro:glasses name="glasses2" parent="room" xyz="-1.1 4.3 0.73" rpy="0 0 0"/>
   
 </robot>
    

--- a/iai_kitchen_defs/room/worktables.urdf.xml
+++ b/iai_kitchen_defs/room/worktables.urdf.xml
@@ -6,23 +6,23 @@
 <!--  <xacro:include filename="$(find iai_maps)/Media/models/chair.urdf.xml"/>-->
 
   <link name="worktables_link">
-    <sphere_inertia radius="0.001" mass="1"/>
+    <xacro:sphere_inertia radius="0.001" mass="1"/>
   </link>
   
-  <table name="work_table_1" parent="worktables" block_pos="-4.05 -0.15 0" block_rpy="0 0 0" material="LightBrown2"/>
-  <table name="work_table_2" parent="worktables" block_pos="-2.44 -0.15 0" block_rpy="0 0 0" material="LightBrown2"/>
-  <table name="work_table_3" parent="worktables" block_pos="-0.83 -0.15 0" block_rpy="0 0 0" material="LightBrown2"/>
-  <table name="work_table_4" parent="worktables" block_pos="0.77 -1.71 0" block_rpy="0 0 1.57" material="LightBrown2"/>
+  <xacro:table name="work_table_1" parent="worktables" block_pos="-4.05 -0.15 0" block_rpy="0 0 0" material="LightBrown2"/>
+  <xacro:table name="work_table_2" parent="worktables" block_pos="-2.44 -0.15 0" block_rpy="0 0 0" material="LightBrown2"/>
+  <xacro:table name="work_table_3" parent="worktables" block_pos="-0.83 -0.15 0" block_rpy="0 0 0" material="LightBrown2"/>
+  <xacro:table name="work_table_4" parent="worktables" block_pos="0.77 -1.71 0" block_rpy="0 0 1.57" material="LightBrown2"/>
 
   <!--
-  <chair name="work_chair_1_1" parent="worktables" xyz="-2.75 0.7 0" rpy="0 0 3.1415"/>
-  <chair name="work_chair_1_2" parent="worktables" xyz="-3.35 0.7 0" rpy="0 0 3.1415"/>
-  <chair name="work_chair_2_1" parent="worktables" xyz="-1.14 0.7 0" rpy="0 0 3.1415"/>
-  <chair name="work_chair_2_2" parent="worktables" xyz="-1.74 0.7 0" rpy="0 0 3.1415"/>
-  <chair name="work_chair_3_1" parent="worktables" xyz="0.47 0.7 0" rpy="0 0 3.1415"/>
-  <chair name="work_chair_3_2" parent="worktables" xyz="-0.13 0.7 0" rpy="0 0 3.1415"/>
-  <chair name="work_chair_4_1" parent="worktables" xyz="0.93 -1.35 0" rpy="0 0 1.57"/>
-  <chair name="work_chair_4_2" parent="worktables" xyz="0.93 -0.7 0" rpy="0 0 1.57"/>
+  <xacro:chair name="work_chair_1_1" parent="worktables" xyz="-2.75 0.7 0" rpy="0 0 3.1415"/>
+  <xacro:chair name="work_chair_1_2" parent="worktables" xyz="-3.35 0.7 0" rpy="0 0 3.1415"/>
+  <xacro:chair name="work_chair_2_1" parent="worktables" xyz="-1.14 0.7 0" rpy="0 0 3.1415"/>
+  <xacro:chair name="work_chair_2_2" parent="worktables" xyz="-1.74 0.7 0" rpy="0 0 3.1415"/>
+  <xacro:chair name="work_chair_3_1" parent="worktables" xyz="0.47 0.7 0" rpy="0 0 3.1415"/>
+  <xacro:chair name="work_chair_3_2" parent="worktables" xyz="-0.13 0.7 0" rpy="0 0 3.1415"/>
+  <xacro:chair name="work_chair_4_1" parent="worktables" xyz="0.93 -1.35 0" rpy="0 0 1.57"/>
+  <xacro:chair name="work_chair_4_2" parent="worktables" xyz="0.93 -0.7 0" rpy="0 0 1.57"/>
   
   -->
   

--- a/iai_maps/launch/kitchen_with_state_publisher.launch
+++ b/iai_maps/launch/kitchen_with_state_publisher.launch
@@ -1,7 +1,7 @@
 <launch>
 
-  <arg name="model" default="$(find iai_kitchen)/urdf/IAI_kitchen.urdf.xacro"/>
-  <param name="kitchen_description" command="$(find xacro)/xacro.py '$(arg model)'" />
+  <arg name="model" default="$(find iai_kitchen)/urdf_obj/iai_kitchen_python.urdf.xacro"/>
+  <param name="kitchen_description" command="$(find xacro)/xacro '$(arg model)'" />
 
   <node pkg="joint_state_publisher" type="joint_state_publisher"
         name="kitchen_joint_state_publisher" output="screen">

--- a/iai_maps/launch/room.launch
+++ b/iai_maps/launch/room.launch
@@ -1,7 +1,7 @@
 <launch>
  
   <param name="room_description" 
-    command="$(find xacro)/xacro.py '$(find iai_kitchen_defs)/room/room.urdf.xml'"
+    command="$(find xacro)/xacro '$(find iai_kitchen_defs)/room/room.urdf.xml'"
   />  
 
   <node pkg="tf" type="static_transform_publisher" name="room_link_broadcaster" 


### PR DESCRIPTION
...and the other xacro files in iai_kitchen_defs as well. Adds `xacro` prefixes to all native and custom macros within iai_kitchen_defs. This is needed for urobosim. The kitchen's urdf is untouched by this PR, it will be covered in a separate PR.

I didn't see any launch file use the xacros in iai_kitchen_defs except for `iai_maps/launch/room.launch`.

I tested this PR by comparing the old room in melodic with this new one in noetic, they look the same. But the walls around the kitchen (where the tables are on which we put our laptops and work and stuff) are outdated and need to be moved. Changing any parameters is not part of this PR though.